### PR TITLE
fix: harden proxy handling and refresh web dashboard

### DIFF
--- a/include/clients/rtsp_to_http_client.h
+++ b/include/clients/rtsp_to_http_client.h
@@ -76,7 +76,7 @@ private:
     };
 
 private:
-    void connect_server();
+    bool connect_server();
     void handle_rtsp(uint32_t event);
     void handle_rtp(uint32_t event);
     void handle_rtcp(uint32_t event);
@@ -139,6 +139,7 @@ private:
 
     std::queue<RtspRequest> request_queue_;
     RtspRequest current_request_;
+    bool request_in_flight_{false};
 
     uint16_t rtp_port_{0};
     sockaddr_in server_rtp_addr_{};

--- a/include/clients/rtsp_to_rtsp_client.h
+++ b/include/clients/rtsp_to_rtsp_client.h
@@ -89,7 +89,7 @@ private:
     /* ------------------------------------------------------------------ */
     /* Internal helpers                                                     */
     /* ------------------------------------------------------------------ */
-    void connect_upstream();
+    bool connect_upstream();
 
     // Patch the SETUP request's Transport header: replace client_port with
     // our local RTP/RTCP port pair.
@@ -151,6 +151,7 @@ private:
     void on_downstream_closed();
     void on_upstream_readable();
     void on_upstream_writable();
+    void finish_upstream_connection();
     void send_rtp_trigger();
     void send_zte_heartbeat();
     void process_pending_setup();
@@ -230,6 +231,9 @@ private:
     // Whether the relay sockets have been set up (after SETUP)
     bool relay_ready_{false};
     bool closed_{false};
+    bool close_after_downstream_flush_{false};
+    uint32_t keepalive_cseq_{1000000000};
+    bool keepalive_pending_{false};
 
     // Track whether we forwarded a PLAY so we can correctly detect the response
     bool pending_play_{false};

--- a/include/handlers/api_handle.h
+++ b/include/handlers/api_handle.h
@@ -10,8 +10,8 @@ class ApiHandle
 public:
     /**
      * Centralized dispatcher for administrative tasks:
-     * - /api/*
-     * - /admin/*
+     * - paths under /api/
+     * - paths under /admin/
      * - /favicon.ico
      * Also handles unauthorized access for these paths.
      * @return true if handled, false if it's a streaming request.
@@ -19,8 +19,8 @@ public:
     static bool dispatch(int client_fd, const RequestInfo &info, EpollLoop *loop, BufferPool &pool);
 
 private:
-    static void serve_admin_file(int client_fd, const RequestInfo &info);
-    static void send_json_response(int client_fd, const nlohmann::json &j);
-    static void send_unauthorized(int client_fd);
+    static void serve_admin_file(int client_fd, const RequestInfo &info, EpollLoop *loop);
+    static void send_json_response(int client_fd, const nlohmann::json &j, EpollLoop *loop);
+    static void send_unauthorized(int client_fd, EpollLoop *loop);
     static std::string get_mime_type(const std::string &path);
 };

--- a/include/handlers/master_handle.h
+++ b/include/handlers/master_handle.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <netinet/in.h>
+#include <cstdint>
+#include <string>
 
 class EpollLoop;
 class BufferPool;
@@ -12,5 +14,7 @@ public:
      * Entry point for every new connection.
      * Identifies the protocol and dispatches to HTTPHandle or RTSPHandle.
      */
-    static void handle(int client_fd, sockaddr_in client_addr, EpollLoop *loop, BufferPool &pool);
+    static void handle(int client_fd, sockaddr_in client_addr, EpollLoop *loop,
+                       BufferPool &pool, std::string &request_buffer,
+                       uint32_t events);
 };

--- a/src/clients/rtsp_to_http_client.cpp
+++ b/src/clients/rtsp_to_http_client.cpp
@@ -10,6 +10,7 @@
 #include "utils/utils.h"
 #include "protocol/rtsp_parser.h"
 #include "utils/socket_helper.h"
+#include "utils/blacklist_checker.h"
 #include "core/port_pool.h"
 #include <sys/socket.h>
 #include <arpa/inet.h>
@@ -17,6 +18,11 @@
 #include <algorithm>
 #include <cstring>
 #include <sys/timerfd.h>
+
+namespace
+{
+constexpr size_t kMaxRtspMessageSize = 1024 * 1024;
+}
 
 RTSPToHttpClient::RTSPToHttpClient(EpollLoop *loop, BufferPool &pool, const sockaddr_in &client_addr, int client_fd, const rtspCtx &ctx)
     : loop_(loop),
@@ -40,6 +46,8 @@ RTSPToHttpClient::RTSPToHttpClient(EpollLoop *loop, BufferPool &pool, const sock
 
     send_http_response();
     init_rtp_rtcp_sockets();
+    if (is_closed_)
+        return;
     if (ServerConfig::isNatEnabled() && ServerConfig::getNatMethod() == "stun")
     {
         StunClient::send_stun_mapping_request(rtp_fd_);
@@ -54,6 +62,8 @@ RTSPToHttpClient::RTSPToHttpClient(EpollLoop *loop, BufferPool &pool, const sock
 void RTSPToHttpClient::set_on_closed_callback(ClosedCallback cb)
 {
     on_closed_callback_ = std::move(cb);
+    if (is_closed_ && on_closed_callback_)
+        on_closed_callback_();
 }
 
 RTSPToHttpClient::~RTSPToHttpClient()
@@ -69,15 +79,15 @@ RTSPToHttpClient::~RTSPToHttpClient()
     }
 }
 
-void RTSPToHttpClient::connect_server()
+bool RTSPToHttpClient::connect_server()
 {
     rtsp_fd_ = create_nonblocking_tcp(ctx.server_ip, ctx.server_rtsp_port, ServerConfig::getHttpUpstreamInterface());
 
     if (rtsp_fd_ < 0)
     {
         Logger::error("[RTSP] Connect to upstream failed.");
-        if (on_closed_callback_) on_closed_callback_();
-        return;
+        on_client_closed();
+        return false;
     }
 
     rtsp_ctx_ = std::make_unique<SocketCtx>(
@@ -88,6 +98,7 @@ void RTSPToHttpClient::connect_server()
     loop_->set(rtsp_ctx_.get(), rtsp_fd_, EPOLLOUT);
 
     state_ = RtspState::CONNECTING;
+    return true;
 }
 
 void RTSPToHttpClient::handle_rtsp(uint32_t event)
@@ -99,6 +110,11 @@ void RTSPToHttpClient::handle_rtsp(uint32_t event)
     if (event & EPOLLOUT)
     {
         on_rtsp_writable();
+    }
+    if ((event & (EPOLLHUP | EPOLLRDHUP | EPOLLERR)) &&
+        !(event & EPOLLIN))
+    {
+        on_client_closed();
     }
 }
 
@@ -148,7 +164,9 @@ void RTSPToHttpClient::handle_timer(uint32_t event)
     if (event & EPOLLIN)
     {
         uint64_t expirations;
-        read(timer_fd_, &expirations, sizeof(expirations));
+        if (read(timer_fd_, &expirations, sizeof(expirations)) !=
+            static_cast<ssize_t>(sizeof(expirations)))
+            return;
         push_request_into_queue(RtspMethod::GET_PARAMETER, "rtsp://" + ctx.server_ip + ":" + std::to_string(ctx.server_rtsp_port) + ctx.path);
         build_and_send_request();
 
@@ -168,7 +186,7 @@ void RTSPToHttpClient::on_rtsp_writable()
         if (getsockopt(rtsp_fd_, SOL_SOCKET, SO_ERROR, &err, &len) < 0 || err != 0)
         {
             Logger::error("[RTSP] Connect to upstream failed.");
-            on_closed_callback_();
+            on_client_closed();
             return;
         }
         Logger::debug("[RTSP] Connection to upstream established.");
@@ -194,11 +212,15 @@ void RTSPToHttpClient::on_rtsp_writable()
             tcp_send_offset_ = 0;
         }
     }
+    else if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+    {
+        return;
+    }
     else
     {
         Logger::error("[RTSP] RTSP control message send failed.");
 
-        on_closed_callback_();
+        on_client_closed();
         return;
     }
 }
@@ -211,13 +233,21 @@ void RTSPToHttpClient::on_rtsp_readable()
         if (n > 0)
         {
             resp_buf_.append(rtsp_buf, n);
+            if (resp_buf_.size() > kMaxRtspMessageSize)
+            {
+                Logger::error("[RTSP] Upstream message exceeds 1 MiB limit");
+                on_client_closed();
+                return;
+            }
             while (!resp_buf_.empty())
             {
                 if (resp_buf_[0] == '$')
                 {
                     if (resp_buf_.size() < 4)
                         break;
-                    uint16_t len = ntohs(*reinterpret_cast<const uint16_t *>(resp_buf_.data() + 2));
+                    uint16_t wire_len = 0;
+                    memcpy(&wire_len, resp_buf_.data() + 2, sizeof(wire_len));
+                    uint16_t len = ntohs(wire_len);
                     if (resp_buf_.size() < static_cast<size_t>(len) + 4)
                         break;
 
@@ -235,11 +265,19 @@ void RTSPToHttpClient::on_rtsp_readable()
 
                 std::string header = resp_buf_.substr(0, end + 4);
                 int content_length = rtspParser::get_content_length(header);
-                if (resp_buf_.size() < end + 4 + content_length)
+                if (content_length < 0 ||
+                    static_cast<size_t>(content_length) > kMaxRtspMessageSize - (end + 4))
+                {
+                    Logger::error("[RTSP] Invalid or oversized Content-Length");
+                    on_client_closed();
+                    return;
+                }
+                size_t message_size = end + 4 + static_cast<size_t>(content_length);
+                if (resp_buf_.size() < message_size)
                     break;
 
                 std::string body = resp_buf_.substr(end + 4, content_length);
-                resp_buf_.erase(0, end + 4 + content_length);
+                resp_buf_.erase(0, message_size);
 
                 rtspParser::parse_session_id(header, ctx);
                 int status = rtspParser::parse_status_code(header);
@@ -251,10 +289,12 @@ void RTSPToHttpClient::on_rtsp_readable()
                     {
                         Logger::debug("[RTSP] Received request from server, responding with 200 OK (CSeq: " + cseq + ")");
                         std::string resp = "RTSP/1.0 200 OK\r\nCSeq: " + cseq + "\r\n\r\n";
-                        send(rtsp_fd_, resp.data(), resp.size(), 0);
+                        send(rtsp_fd_, resp.data(), resp.size(), MSG_NOSIGNAL);
                         continue;
                     }
                 }
+
+                request_in_flight_ = false;
 
                 if (status == 461 && current_request_.method == RtspMethod::SETUP && !setup_retry_with_tcp_)
                 {
@@ -270,14 +310,14 @@ void RTSPToHttpClient::on_rtsp_readable()
                     if (location.empty())
                     {
                         Logger::error("[RTSP] Redirect status " + std::to_string(status) + " received but Location header is missing.");
-                        on_closed_callback_();
+                        on_client_closed();
                         return;
                     }
 
                     if (++redirect_count_ > 3)
                     {
                         Logger::error("[RTSP] Too many redirects (limit 3 exceeded).");
-                        on_closed_callback_();
+                        on_client_closed();
                         return;
                     }
 
@@ -287,7 +327,17 @@ void RTSPToHttpClient::on_rtsp_readable()
                     if (rtspParser::parse_url(location, temp_ctx) != 0)
                     {
                         Logger::error("[RTSP] Failed to parse redirect Location URL: " + location);
-                        on_closed_callback_();
+                        on_client_closed();
+                        return;
+                    }
+
+                    if (BlacklistChecker::is_blacklisted(temp_ctx.server_ip) ||
+                        BlacklistChecker::is_loopback(temp_ctx.server_ip,
+                                                      temp_ctx.server_rtsp_port,
+                                                      client_fd_))
+                    {
+                        Logger::error("[RTSP] Redirect target is blocked: " + location);
+                        on_client_closed();
                         return;
                     }
 
@@ -311,6 +361,7 @@ void RTSPToHttpClient::on_rtsp_readable()
 
                     tcp_send_offset_ = 0;
                     resp_buf_.clear();
+                    request_in_flight_ = true;
 
                     rtsp_ctx_.reset();
                     rtsp_fd_ = -1;
@@ -322,7 +373,7 @@ void RTSPToHttpClient::on_rtsp_readable()
                 if (status != 200)
                 {
                     Logger::error("[RTSP] Connection to upstream refused. Status: " + std::to_string(status) + ", Header: " + header);
-                    on_closed_callback_();
+                    on_client_closed();
                     return;
                 }
 
@@ -340,7 +391,7 @@ void RTSPToHttpClient::on_rtsp_readable()
                     if (rtspParser::parse_server_ports(header, ctx) != 0)
                     {
                         Logger::error("Can't parser server port");
-                        on_closed_callback_();
+                        on_client_closed();
                         return;
                     }
 
@@ -383,7 +434,7 @@ void RTSPToHttpClient::on_rtsp_readable()
         else if (n == 0)
         {
             Logger::debug("[RTSP] Server closed connection");
-            on_closed_callback_();
+            on_client_closed();
             return;
         }
         else if (errno == EAGAIN || errno == EWOULDBLOCK)
@@ -393,7 +444,7 @@ void RTSPToHttpClient::on_rtsp_readable()
         else
         {
             Logger::warn("[RTSP] Receive failed");
-            on_closed_callback_();
+            on_client_closed();
             return;
         }
     }
@@ -506,7 +557,8 @@ void RTSPToHttpClient::on_client_writable()
     while (!send_queue_.empty())
     {
         auto &packet = send_queue_.front();
-        ssize_t n = send(client_fd_, packet.data.get() + packet.offset, packet.length - packet.offset, 0);
+        ssize_t n = send(client_fd_, packet.data.get() + packet.offset,
+                         packet.length - packet.offset, MSG_NOSIGNAL);
         if (n < 0)
         {
             if (errno == EAGAIN || errno == EWOULDBLOCK)
@@ -518,7 +570,13 @@ void RTSPToHttpClient::on_client_writable()
             }
         }
 
-        Statistics::getInstance().addDownstreamBytes(n);
+        if (n == 0)
+        {
+            on_client_closed();
+            return;
+        }
+
+        Statistics::getInstance().addDownstreamBytes(static_cast<size_t>(n));
         downstream_est_.addBytes(n);
         packet.offset += n;
 
@@ -557,7 +615,7 @@ void RTSPToHttpClient::push_request_into_queue(RtspMethod method, const std::str
 
 void RTSPToHttpClient::build_and_send_request()
 {
-    if (!request_queue_.empty())
+    if (!request_in_flight_ && !request_queue_.empty() && rtsp_fd_ >= 0 && rtsp_ctx_)
     {
         current_request_ = request_queue_.front();
         request_queue_.pop();
@@ -574,6 +632,7 @@ void RTSPToHttpClient::build_and_send_request()
             req_buf_ += "\r\n";
 
         tcp_send_offset_ = 0;
+        request_in_flight_ = true;
         loop_->set(rtsp_ctx_.get(), rtsp_fd_, EPOLLOUT);
     }
 }
@@ -583,7 +642,7 @@ void RTSPToHttpClient::init_rtp_rtcp_sockets()
     if (bind_udp_pair_from_pool(rtp_fd_.get_ref(), rtcp_fd_.get_ref(), rtp_port_, ServerConfig::getHttpUpstreamInterface()) < 0)
     {
         Logger::error("[RTP] Failed to bind RTP/RTCP sockets from pool");
-        if (on_closed_callback_) on_closed_callback_();
+        on_client_closed();
         return;
     }
 
@@ -663,15 +722,25 @@ void RTSPToHttpClient::init_timer_fd()
 {
     using namespace std::chrono;
 
-    // Use FdGuard to ensure old FD is removed from epoll and closed
-    timer_fd_ = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+    int new_timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+    if (new_timer_fd < 0)
+    {
+        Logger::warn("[RTSP] Failed to create keepalive timer");
+        return;
+    }
+    timer_fd_ = new_timer_fd;
     itimerspec its{};
     auto interval = seconds(20);
 
     its.it_value.tv_sec = interval.count();
     its.it_interval.tv_sec = interval.count();
 
-    timerfd_settime(timer_fd_, 0, &its, nullptr);
+    if (timerfd_settime(timer_fd_, 0, &its, nullptr) < 0)
+    {
+        Logger::warn("[RTSP] Failed to arm keepalive timer");
+        timer_fd_ = -1;
+        return;
+    }
 
     // Defer deletion of old context if it exists
     if (timer_ctx_)
@@ -689,8 +758,6 @@ void RTSPToHttpClient::init_timer_fd()
 
 void RTSPToHttpClient::send_http_response()
 {
-    auto buf = buffer_pool_.acquire();
-
     const char *response_header =
         "HTTP/1.1 200 OK\r\n"
         "Content-Type: video/mp2t\r\n"
@@ -698,9 +765,17 @@ void RTSPToHttpClient::send_http_response()
         "\r\n";
 
     size_t len = strlen(response_header);
-    memcpy(buf.get(), response_header, len);
-
-    send_queue_.push_back(Packet{std::move(buf), len, 0});
+    size_t offset = 0;
+    while (offset < len)
+    {
+        auto buf = buffer_pool_.acquire();
+        size_t chunk = std::min(buffer_pool_.get_buffer_size(), len - offset);
+        memcpy(buf.get(), response_header + offset, chunk);
+        send_queue_.push_back(Packet{std::move(buf), chunk, 0});
+        offset += chunk;
+    }
+    loop_->set(client_ctx_.get(), client_fd_,
+               EPOLLRDHUP | EPOLLHUP | EPOLLERR | EPOLLOUT);
 }
 
 
@@ -731,7 +806,8 @@ std::string RTSPToHttpClient::RtspMethodToString(RtspMethod method)
 
 void RTSPToHttpClient::send_rtsp_option()
 {
-    connect_server();
+    if (!connect_server())
+        return;
     push_request_into_queue(RtspMethod::OPTIONS, "rtsp://" + ctx.server_ip + ":" + std::to_string(ctx.server_rtsp_port) + ctx.path, "", "");
     build_and_send_request();
 }

--- a/src/clients/rtsp_to_rtsp_client.cpp
+++ b/src/clients/rtsp_to_rtsp_client.cpp
@@ -10,6 +10,7 @@
 #include "protocol/rtsp_parser.h"
 #include "utils/socket_helper.h"
 #include "utils/stun_client.h"
+#include "utils/blacklist_checker.h"
 #include "core/port_pool.h"
 #include <sys/socket.h>
 #include <arpa/inet.h>
@@ -19,6 +20,36 @@
 #include <sys/timerfd.h>
 #include <chrono>
 #include <regex>
+
+namespace
+{
+constexpr size_t kMaxRtspMessageSize = 1024 * 1024;
+
+bool parse_content_length(const std::string &headers, size_t &body_len)
+{
+    body_len = 0;
+    std::string value = rtspParser::extract_header_value(headers, "Content-Length");
+    if (value.empty())
+        return true;
+
+    try
+    {
+        size_t parsed = 0;
+        unsigned long long length = std::stoull(value, &parsed);
+        while (parsed < value.size() &&
+               (value[parsed] == ' ' || value[parsed] == '\t'))
+            ++parsed;
+        if (parsed != value.size() || length > kMaxRtspMessageSize)
+            return false;
+        body_len = static_cast<size_t>(length);
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+}
 
 
 /* ========================================================================= */
@@ -89,7 +120,8 @@ RTSPToRtspClient::RTSPToRtspClient(EpollLoop *loop, BufferPool &pool,
     loop_->set(downstream_ctx_.get(), client_fd,
                EPOLLRDHUP | EPOLLHUP | EPOLLERR);
 
-    connect_upstream();
+    if (!connect_upstream())
+        close_all();
 }
 
 RTSPToRtspClient::~RTSPToRtspClient()
@@ -112,20 +144,23 @@ RTSPToRtspClient::~RTSPToRtspClient()
 void RTSPToRtspClient::set_on_closed_callback(ClosedCallback cb)
 {
     on_closed_ = std::move(cb);
+    if (closed_ && on_closed_)
+        on_closed_();
 }
 
 /* ========================================================================= */
 /* Connect to upstream                                                        */
 /* ========================================================================= */
 
-void RTSPToRtspClient::connect_upstream()
+bool RTSPToRtspClient::connect_upstream()
 {
     upstream_fd_ = create_nonblocking_tcp(ctx_.server_ip, ctx_.server_rtsp_port,
                                           ServerConfig::getMitmUpstreamInterface());
     if (upstream_fd_ < 0)
     {
-        throw std::runtime_error("Failed to connect to upstream " + ctx_.server_ip +
-                                ":" + std::to_string(ctx_.server_rtsp_port));
+        Logger::error("[MITM] Failed to connect to upstream " + ctx_.server_ip +
+                      ":" + std::to_string(ctx_.server_rtsp_port));
+        return false;
     }
 
     upstream_ctx_ = std::make_unique<SocketCtx>(
@@ -135,6 +170,7 @@ void RTSPToRtspClient::connect_upstream()
     // EPOLLOUT fires when non-blocking connect completes.
     loop_->set(upstream_ctx_.get(), upstream_fd_, EPOLLOUT);
     state_ = State::WAIT_UPSTREAM_CONNECT;
+    return true;
 }
 
 /* ========================================================================= */
@@ -154,9 +190,21 @@ bool RTSPToRtspClient::extract_client_port(const std::string &req,
     if (!std::regex_search(transport, m, re))
         return false;
 
-    rtp_port = static_cast<uint16_t>(std::stoi(m[1]));
-    rtcp_port = static_cast<uint16_t>(std::stoi(m[2]));
-    return true;
+    try
+    {
+        int parsed_rtp = std::stoi(m[1]);
+        int parsed_rtcp = std::stoi(m[2]);
+        if (parsed_rtp < 1 || parsed_rtp > 65535 ||
+            parsed_rtcp < 1 || parsed_rtcp > 65535)
+            return false;
+        rtp_port = static_cast<uint16_t>(parsed_rtp);
+        rtcp_port = static_cast<uint16_t>(parsed_rtcp);
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
 }
 
 bool RTSPToRtspClient::extract_interleaved_channels(const std::string &req,
@@ -172,9 +220,21 @@ bool RTSPToRtspClient::extract_interleaved_channels(const std::string &req,
     if (!std::regex_search(transport, m, re))
         return false;
 
-    rtp_chan = static_cast<uint8_t>(std::stoi(m[1]));
-    rtcp_chan = static_cast<uint8_t>(std::stoi(m[2]));
-    return true;
+    try
+    {
+        int parsed_rtp = std::stoi(m[1]);
+        int parsed_rtcp = std::stoi(m[2]);
+        if (parsed_rtp < 0 || parsed_rtp > 255 ||
+            parsed_rtcp < 0 || parsed_rtcp > 255)
+            return false;
+        rtp_chan = static_cast<uint8_t>(parsed_rtp);
+        rtcp_chan = static_cast<uint8_t>(parsed_rtcp);
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
 }
 
 bool RTSPToRtspClient::init_relay_sockets()
@@ -257,12 +317,20 @@ std::string RTSPToRtspClient::patch_response_for_client(const std::string &resp)
         {
             uint16_t srv_rtp = static_cast<uint16_t>(std::stoi(sm[1]));
             uint16_t srv_rtcp = static_cast<uint16_t>(std::stoi(sm[2]));
+            std::string rtp_source = ctx_.server_ip;
+            std::regex source_re(R"(source=([0-9.]+))");
+            std::smatch source_match;
+            if (std::regex_search(transport, source_match, source_re) &&
+                !BlacklistChecker::is_blacklisted(source_match[1]))
+            {
+                rtp_source = source_match[1];
+            }
             server_rtp_addr_.sin_family = AF_INET;
             server_rtp_addr_.sin_port = htons(srv_rtp);
-            inet_pton(AF_INET, ctx_.server_ip.c_str(), &server_rtp_addr_.sin_addr);
+            inet_pton(AF_INET, rtp_source.c_str(), &server_rtp_addr_.sin_addr);
             server_rtcp_addr_.sin_family = AF_INET;
             server_rtcp_addr_.sin_port = htons(srv_rtcp);
-            inet_pton(AF_INET, ctx_.server_ip.c_str(), &server_rtcp_addr_.sin_addr);
+            inet_pton(AF_INET, rtp_source.c_str(), &server_rtcp_addr_.sin_addr);
             
             if (!is_upstream_tcp_)
             {
@@ -507,12 +575,23 @@ std::string RTSPToRtspClient::rewrite_request_for_upstream(const std::string &re
 void RTSPToRtspClient::init_timer_fd()
 {
     using namespace std::chrono;
-    timer_fd_ = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+    int new_timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+    if (new_timer_fd < 0)
+    {
+        Logger::warn("[MITM] Failed to create keepalive timer");
+        return;
+    }
+    timer_fd_ = new_timer_fd;
     itimerspec its{};
     auto interval = seconds(20);
     its.it_value.tv_sec = interval.count();
     its.it_interval.tv_sec = interval.count();
-    timerfd_settime(timer_fd_, 0, &its, nullptr);
+    if (timerfd_settime(timer_fd_, 0, &its, nullptr) < 0)
+    {
+        Logger::warn("[MITM] Failed to arm keepalive timer");
+        timer_fd_ = -1;
+        return;
+    }
 
     if (timer_ctx_)
     {
@@ -549,10 +628,13 @@ void RTSPToRtspClient::handle_upstream(uint32_t events)
         on_upstream_writable();
     if (events & EPOLLIN)
         on_upstream_readable();
-    if (events & (EPOLLHUP | EPOLLRDHUP | EPOLLERR))
+    // When EPOLLIN and HUP arrive together, data is still waiting in the
+    // socket. Drain it on subsequent level-triggered EPOLLIN events first.
+    if ((events & (EPOLLHUP | EPOLLRDHUP | EPOLLERR)) &&
+        !(events & EPOLLIN))
     {
         Logger::debug("[MITM] Upstream connection closed");
-        close_all();
+        finish_upstream_connection();
     }
 }
 
@@ -599,9 +681,9 @@ void RTSPToRtspClient::handle_rtp_from_upstream(uint32_t /*events*/)
             break;
         }
 
-        // Packet from upstream server -> send to downstream client
-        // if (src.sin_port == server_rtp_addr_.sin_port &&
-        //     src.sin_addr.s_addr == server_rtp_addr_.sin_addr.s_addr)
+        // Ignore datagrams that did not come from the negotiated RTP endpoint.
+        if (src.sin_port == server_rtp_addr_.sin_port &&
+            src.sin_addr.s_addr == server_rtp_addr_.sin_addr.s_addr)
         {
             upstream_est_.addBytes(n);
             Statistics::getInstance().addUpstreamBytes(n);
@@ -645,9 +727,8 @@ void RTSPToRtspClient::handle_rtcp_from_upstream(uint32_t /*events*/)
             break;
         }
 
-        // Packet from upstream server -> send to downstream client
-        // if (src.sin_port == server_rtcp_addr_.sin_port &&
-        //     src.sin_addr.s_addr == server_rtcp_addr_.sin_addr.s_addr)
+        if (src.sin_port == server_rtcp_addr_.sin_port &&
+            src.sin_addr.s_addr == server_rtcp_addr_.sin_addr.s_addr)
         {
             upstream_est_.addBytes(n);
             Statistics::getInstance().addUpstreamBytes(n);
@@ -672,6 +753,12 @@ void RTSPToRtspClient::send_interleaved_downstream(uint8_t channel, const uint8_
     if (closed_ || downstream_fd_ < 0) return;
 
     size_t pool_block_size = pool_.get_buffer_size();
+    if (pool_block_size <= 4)
+    {
+        Logger::error("[MITM] Buffer pool block is too small for interleaved RTP");
+        close_all();
+        return;
+    }
     if (len + 4 > pool_block_size) {
         Logger::warn("[MITM] Packet too large, truncated (" + std::to_string(len + 4) + " > " + std::to_string(pool_block_size) + ")");
         len = pool_block_size - 4;
@@ -830,12 +917,19 @@ void RTSPToRtspClient::handle_rtcp_from_client(uint32_t /*events*/)
 void RTSPToRtspClient::handle_timer(uint32_t /*events*/)
 {
     uint64_t exp;
-    read(timer_fd_, &exp, sizeof(exp));
+    if (read(timer_fd_, &exp, sizeof(exp)) !=
+        static_cast<ssize_t>(sizeof(exp)))
+        return;
+    if (keepalive_pending_ || upstream_fd_ < 0)
+        return;
+
+    uint32_t cseq = keepalive_cseq_++;
     // Send a GET_PARAMETER to upstream as keepalive.
     std::string ka = "GET_PARAMETER " + ctx_.rtsp_url + " RTSP/1.0\r\n"
-                     "CSeq: 99\r\n"
+                     "CSeq: " + std::to_string(cseq) + "\r\n"
                      "Session: " + ctx_.session_id + "\r\n"
                      "\r\n";
+    keepalive_pending_ = true;
     to_upstream_q_.push_back(ka);
     loop_->set(upstream_ctx_.get(), upstream_fd_, EPOLLIN | EPOLLOUT);
 
@@ -861,6 +955,12 @@ void RTSPToRtspClient::on_downstream_readable()
     }
     buf[n] = 0;
     downstream_recv_buf_.append(buf, n);
+    if (downstream_recv_buf_.size() > kMaxRtspMessageSize)
+    {
+        Logger::warn("[MITM] Downstream RTSP message exceeds 1 MiB limit");
+        close_all();
+        return;
+    }
 
     // Wait for a complete RTSP message (ends with \r\n\r\n) or Interleaved packet ($)
     while (!downstream_recv_buf_.empty())
@@ -870,7 +970,9 @@ void RTSPToRtspClient::on_downstream_readable()
             if (downstream_recv_buf_.size() < 4)
                 break;
             
-            uint16_t len = ntohs(*reinterpret_cast<const uint16_t *>(downstream_recv_buf_.data() + 2));
+            uint16_t wire_len = 0;
+            memcpy(&wire_len, downstream_recv_buf_.data() + 2, sizeof(wire_len));
+            uint16_t len = ntohs(wire_len);
             if (downstream_recv_buf_.size() < static_cast<size_t>(len) + 4)
                 break;
 
@@ -884,9 +986,20 @@ void RTSPToRtspClient::on_downstream_readable()
         if (end == std::string::npos)
             break;
 
-        // Include the trailing \r\n\r\n
-        std::string req = downstream_recv_buf_.substr(0, end + 4);
-        downstream_recv_buf_ = downstream_recv_buf_.substr(end + 4);
+        size_t body_len = 0;
+        if (!parse_content_length(downstream_recv_buf_.substr(0, end + 4), body_len) ||
+            body_len > kMaxRtspMessageSize - (end + 4))
+        {
+            Logger::warn("[MITM] Invalid downstream Content-Length");
+            close_all();
+            return;
+        }
+        size_t total = end + 4 + body_len;
+        if (downstream_recv_buf_.size() < total)
+            break;
+
+        std::string req = downstream_recv_buf_.substr(0, total);
+        downstream_recv_buf_.erase(0, total);
 
         last_downstream_req_ = req;
 
@@ -970,7 +1083,7 @@ void RTSPToRtspClient::on_downstream_writable()
         auto &packet = to_downstream_q_.front();
         ssize_t n = send(downstream_fd_,
                          packet.data.get() + packet.offset,
-                         packet.length - packet.offset, 0);
+                         packet.length - packet.offset, MSG_NOSIGNAL);
         if (n > 0)
         {
             Statistics::getInstance().addDownstreamBytes(n);
@@ -995,6 +1108,11 @@ void RTSPToRtspClient::on_downstream_writable()
     // Once the queue is empty, go back to only waiting for incoming data.
     if (to_downstream_q_.empty())
     {
+        if (close_after_downstream_flush_)
+        {
+            close_all();
+            return;
+        }
         loop_->set(downstream_ctx_.get(), downstream_fd_,
                    EPOLLRDHUP | EPOLLHUP | EPOLLERR | EPOLLIN);
     }
@@ -1053,7 +1171,7 @@ void RTSPToRtspClient::on_upstream_writable()
         auto &msg = to_upstream_q_.front();
         ssize_t n = send(upstream_fd_,
                          msg.data() + upstream_send_offset_,
-                         msg.size() - upstream_send_offset_, 0);
+                         msg.size() - upstream_send_offset_, MSG_NOSIGNAL);
         if (n > 0)
         {
             upstream_send_offset_ += n;
@@ -1092,12 +1210,18 @@ void RTSPToRtspClient::on_upstream_readable()
         if (n == 0 || (errno != EAGAIN && errno != EWOULDBLOCK))
         {
             Logger::debug("[MITM] Upstream closed connection");
-            close_all();
+            finish_upstream_connection();
         }
         return;
     }
     buf[n] = 0;
     upstream_recv_buf_.append(buf, n);
+    if (upstream_recv_buf_.size() > kMaxRtspMessageSize)
+    {
+        Logger::warn("[MITM] Upstream RTSP message exceeds 1 MiB limit");
+        close_all();
+        return;
+    }
 
     // Forward complete RTSP responses or handle Interleaved packets
     while (!upstream_recv_buf_.empty())
@@ -1107,7 +1231,9 @@ void RTSPToRtspClient::on_upstream_readable()
             if (upstream_recv_buf_.size() < 4)
                 break;
             
-            uint16_t len = ntohs(*reinterpret_cast<const uint16_t *>(upstream_recv_buf_.data() + 2));
+            uint16_t wire_len = 0;
+            memcpy(&wire_len, upstream_recv_buf_.data() + 2, sizeof(wire_len));
+            uint16_t len = ntohs(wire_len);
             if (upstream_recv_buf_.size() < static_cast<size_t>(len) + 4)
                 break;
 
@@ -1123,11 +1249,12 @@ void RTSPToRtspClient::on_upstream_readable()
 
         // A response may have a body (SDP). Read Content-Length.
         size_t body_len = 0;
-        std::string cl_val = rtspParser::extract_header_value(
-            upstream_recv_buf_.substr(0, end + 4), "Content-Length");
-        if (!cl_val.empty())
+        if (!parse_content_length(upstream_recv_buf_.substr(0, end + 4), body_len) ||
+            body_len > kMaxRtspMessageSize - (end + 4))
         {
-            try { body_len = std::stoul(cl_val); } catch (...) {}
+            Logger::warn("[MITM] Invalid upstream Content-Length");
+            close_all();
+            return;
         }
 
         size_t total = end + 4 + body_len;
@@ -1137,9 +1264,15 @@ void RTSPToRtspClient::on_upstream_readable()
         std::string resp = upstream_recv_buf_.substr(0, total);
         upstream_recv_buf_ = upstream_recv_buf_.substr(total);
 
-        // Check if this is a response to our injected keepalive (CSeq: 99).
-        if (resp.find("CSeq: 99\r\n") != std::string::npos)
+        // Consume only the response to the currently pending injected
+        // keepalive; do not swallow a downstream request that happens to use
+        // the same fixed CSeq.
+        std::string response_cseq = rtspParser::extract_header_value(resp, "CSeq");
+        uint32_t expected_keepalive_cseq = keepalive_cseq_ - 1;
+        if (keepalive_pending_ &&
+            response_cseq == std::to_string(expected_keepalive_cseq))
         {
+            keepalive_pending_ = false;
             Logger::debug("[MITM] Consumed keepalive response from upstream");
             continue;
         }
@@ -1176,6 +1309,16 @@ void RTSPToRtspClient::on_upstream_readable()
                 return;
             }
 
+            if (BlacklistChecker::is_blacklisted(temp_ctx.server_ip) ||
+                BlacklistChecker::is_loopback(temp_ctx.server_ip,
+                                              temp_ctx.server_rtsp_port,
+                                              downstream_fd_))
+            {
+                Logger::error("[MITM] Redirect target is blocked: " + location);
+                close_all();
+                return;
+            }
+
             // Update ctx_ with the new location info
             ctx_.server_ip = temp_ctx.server_ip;
             ctx_.server_rtsp_port = temp_ctx.server_rtsp_port;
@@ -1199,7 +1342,8 @@ void RTSPToRtspClient::on_upstream_readable()
             to_upstream_q_.push_back(rewritten_req);
 
             // Connect to the new upstream server
-            connect_upstream();
+            if (!connect_upstream())
+                close_all();
             return;
         }
 
@@ -1253,13 +1397,41 @@ void RTSPToRtspClient::on_upstream_readable()
             }
         }
 
-        // Convert RTSP response string to Packet
-        auto buf = pool_.acquire();
-        memcpy(buf.get(), resp.data(), resp.size());
-        to_downstream_q_.push_back(Packet{std::move(buf), resp.size(), 0});
+        // A control response (especially SDP) can be much larger than one
+        // fixed-size RTP pool block. Queue it in safe chunks.
+        size_t response_offset = 0;
+        while (response_offset < resp.size())
+        {
+            auto response_buf = pool_.acquire();
+            size_t chunk = std::min(pool_.get_buffer_size(),
+                                    resp.size() - response_offset);
+            memcpy(response_buf.get(), resp.data() + response_offset, chunk);
+            to_downstream_q_.push_back(
+                Packet{std::move(response_buf), chunk, 0});
+            response_offset += chunk;
+        }
         loop_->set(downstream_ctx_.get(), downstream_fd_,
                    EPOLLRDHUP | EPOLLHUP | EPOLLERR | EPOLLOUT | EPOLLIN);
     }
+}
+
+void RTSPToRtspClient::finish_upstream_connection()
+{
+    if (closed_ || close_after_downstream_flush_)
+        return;
+
+    if (upstream_fd_ >= 0)
+        upstream_fd_ = -1;
+
+    if (to_downstream_q_.empty())
+    {
+        close_all();
+        return;
+    }
+
+    close_after_downstream_flush_ = true;
+    loop_->set(downstream_ctx_.get(), downstream_fd_,
+               EPOLLRDHUP | EPOLLHUP | EPOLLERR | EPOLLIN | EPOLLOUT);
 }
 
 /* ========================================================================= */

--- a/src/core/proxy_server.cpp
+++ b/src/core/proxy_server.cpp
@@ -43,7 +43,15 @@ ProxyServer::~ProxyServer() {}
 int ProxyServer::run(int argc, char *argv[])
 {
     // 1. Parse command line and load config
-    ServerConfig::parseCommandLine(argc, argv);
+    try
+    {
+        ServerConfig::parseCommandLine(argc, argv);
+    }
+    catch (const std::exception &e)
+    {
+        Logger::error("[CONFIG] Invalid configuration: " + std::string(e.what()));
+        return EXIT_FAILURE;
+    }
     
     if (!ServerConfig::getLogFile().empty()) {
         Logger::setLogFile(ServerConfig::getLogFile(), ServerConfig::getLogLines());
@@ -141,6 +149,7 @@ void ProxyServer::setup_signals()
 {
     signal(SIGINT, worker_sig_handler);
     signal(SIGTERM, worker_sig_handler);
+    signal(SIGPIPE, SIG_IGN);
     
     if (ServerConfig::isWatchdogEnabled()) {
         signal(SIGSEGV, crash_handler);
@@ -171,14 +180,16 @@ void ProxyServer::setup_accept_handler(int listen_fd, EpollLoop &loop, BufferPoo
             set_tcp_nodelay(client_fd);
 
             auto ctx = std::make_unique<SocketCtx>();
+            auto request_buffer = std::make_shared<std::string>();
             ctx->fd = client_fd;
-            ctx->handler = [client_fd, client_addr, &loop, &pool](uint32_t e)
+            ctx->handler = [client_fd, client_addr, &loop, &pool, request_buffer](uint32_t e)
             {
-                [[maybe_unused]] uint32_t unused_events = e;
-                MasterHandle::handle(client_fd, client_addr, &loop, pool);
+                MasterHandle::handle(client_fd, client_addr, &loop, pool,
+                                     *request_buffer, e);
             };
 
-            loop.set(std::move(ctx), client_fd, EPOLLIN);
+            loop.set(std::move(ctx), client_fd,
+                     EPOLLIN | EPOLLRDHUP | EPOLLHUP | EPOLLERR);
         }
     };
 

--- a/src/core/server_config.cpp
+++ b/src/core/server_config.cpp
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <cstring>
+#include <stdexcept>
 
 int ServerConfig::port = 8554;
 bool ServerConfig::enable_nat = false;
@@ -110,6 +111,8 @@ void ServerConfig::parseCommandLine(int argc, char *argv[])
 
 void ServerConfig::setPort(int p)
 {
+    if (p < 1 || p > 65535)
+        throw std::out_of_range("listen port must be in range 1..65535");
     port = p;
 }
 
@@ -120,21 +123,29 @@ void ServerConfig::setNatEnabled(bool enable)
 
 void ServerConfig::setNatMethod(const std::string &method)
 {
+    if (method != "stun" && method != "zte")
+        throw std::invalid_argument("nat_method must be 'stun' or 'zte'");
     nat_method = method;
 }
 
 void ServerConfig::setBufferPoolCount(int count)
 {
+    if (count < 1 || count > 262144)
+        throw std::out_of_range("buffer_pool_count must be in range 1..262144");
     buffer_pool_count = count;
 }
 
 void ServerConfig::setBufferPoolBlockSize(int size)
 {
+    if (size < 64 || size > 65536)
+        throw std::out_of_range("buffer_pool_block_size must be in range 64..65536");
     buffer_pool_block_size = size;
 }
 
 void ServerConfig::setStunPort(int port)
 {
+    if (port < 1 || port > 65535)
+        throw std::out_of_range("STUN port must be in range 1..65535");
     stun_server_port = port;
 }
 

--- a/src/handlers/api_handle.cpp
+++ b/src/handlers/api_handle.cpp
@@ -1,13 +1,61 @@
 #include "handlers/api_handle.h"
 #include "core/statistics.h"
 #include "core/logger.h"
+#include "common/socket_ctx.h"
 #include "3rd/json.hpp"
 #include <sys/socket.h>
 #include <unistd.h>
 #include <fstream>
 #include <sstream>
+#include <filesystem>
+#include <memory>
+#include <cerrno>
 
 using json = nlohmann::json;
+
+namespace
+{
+void send_response(EpollLoop *loop, int client_fd, std::string response)
+{
+    auto data = std::make_shared<std::string>(std::move(response));
+    auto offset = std::make_shared<size_t>(0);
+    auto ctx = std::make_unique<SocketCtx>();
+    ctx->fd = client_fd;
+    ctx->handler = [loop, client_fd, data, offset](uint32_t events)
+    {
+        auto close_connection = [loop, client_fd]()
+        {
+            loop->remove(client_fd);
+            close(client_fd);
+        };
+
+        if (events & (EPOLLHUP | EPOLLERR))
+        {
+            close_connection();
+            return;
+        }
+
+        while (*offset < data->size())
+        {
+            ssize_t n = send(client_fd, data->data() + *offset,
+                             data->size() - *offset, MSG_NOSIGNAL);
+            if (n > 0)
+            {
+                *offset += static_cast<size_t>(n);
+                continue;
+            }
+            if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+                return;
+            close_connection();
+            return;
+        }
+
+        close_connection();
+    };
+
+    loop->set(std::move(ctx), client_fd, EPOLLOUT | EPOLLHUP | EPOLLERR);
+}
+}
 
 bool ApiHandle::dispatch(int client_fd, const RequestInfo &info, EpollLoop *loop, BufferPool &pool)
 {
@@ -15,20 +63,22 @@ bool ApiHandle::dispatch(int client_fd, const RequestInfo &info, EpollLoop *loop
 
     // 1. Route match checks
     bool is_api = (path.find("/api/") == 0);
-    bool is_admin = (path.find("/admin") == 0);
+    bool is_admin = (path == "/admin" || path.find("/admin/") == 0);
     bool is_favicon = (path == "/favicon.ico");
 
     if (!is_api && !is_admin && !is_favicon) return false;
 
     // 2. Authorization check
-    bool is_static = (path.find(".js") != std::string::npos || 
-                      path.find(".css") != std::string::npos || 
-                      path.find(".ico") != std::string::npos);
+    size_t query_pos = path.find('?');
+    std::string route_path = path.substr(0, query_pos);
+    bool is_static = (route_path == "/admin/main.js" ||
+                      route_path == "/admin/style.css" ||
+                      route_path == "/favicon.ico");
 
     if (!info.is_authorized && !is_static)
     {
         Logger::debug("[SERVER] Unauthorized admin access: " + path);
-        send_unauthorized(client_fd);
+        send_unauthorized(client_fd, loop);
         return true;
     }
 
@@ -36,14 +86,13 @@ bool ApiHandle::dispatch(int client_fd, const RequestInfo &info, EpollLoop *loop
     if (is_favicon)
     {
         std::string resp = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
-        send(client_fd, resp.c_str(), resp.size(), 0);
-        close(client_fd);
+        send_response(loop, client_fd, std::move(resp));
         return true;
     }
 
     if (is_api)
     {
-        if (path.find("/api/status") == 0)
+        if (route_path == "/api/status")
         {
             json status;
             status["pool"]["available"] = pool.get_available_count();
@@ -63,32 +112,35 @@ bool ApiHandle::dispatch(int client_fd, const RequestInfo &info, EpollLoop *loop
             status["stats"]["active_clients"] = stats.getActiveClients();
             status["clients"] = loop->get_all_clients_info();
             
-            send_json_response(client_fd, status);
+            send_json_response(client_fd, status, loop);
             return true;
         }
         
-        if (path.find("/api/logs") == 0)
+        if (route_path == "/api/logs")
         {
             json response;
             response["logs"] = Logger::getRecentLogs();
             response["level"] = (int)Logger::getLogLevel();
-            send_json_response(client_fd, response);
+            send_json_response(client_fd, response, loop);
             return true;
         }
     }
 
     if (is_admin)
     {
-        serve_admin_file(client_fd, info);
+        serve_admin_file(client_fd, info, loop);
         return true;
     }
 
     return false;
 }
 
-void ApiHandle::serve_admin_file(int client_fd, const RequestInfo &info)
+void ApiHandle::serve_admin_file(int client_fd, const RequestInfo &info, EpollLoop *loop)
 {
     std::string clean_path = info.clean_uri;
+    size_t query_pos = clean_path.find('?');
+    if (query_pos != std::string::npos)
+        clean_path.erase(query_pos);
 
     if (clean_path == "/admin")
     {
@@ -97,16 +149,33 @@ void ApiHandle::serve_admin_file(int client_fd, const RequestInfo &info)
                                "Content-Length: 0\r\n"
                                "Connection: close\r\n"
                                "\r\n";
-        send(client_fd, response.c_str(), response.size(), 0);
-        close(client_fd);
+        send_response(loop, client_fd, std::move(response));
         return;
     }
 
     if (clean_path == "/admin/") clean_path = "/admin/index.html";
+
+    std::filesystem::path relative_path(clean_path.substr(7));
+    if (relative_path.empty() || relative_path.is_absolute())
+    {
+        std::string response = "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+        send_response(loop, client_fd, std::move(response));
+        return;
+    }
+    for (const auto &component : relative_path)
+    {
+        if (component == ".." || component == ".")
+        {
+            Logger::warn("[SERVER] Rejected unsafe admin path: " + clean_path);
+            std::string response = "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            send_response(loop, client_fd, std::move(response));
+            return;
+        }
+    }
     
     // Path resolution
-    std::string rel_path = "webui" + clean_path.substr(6);
-    std::string sys_path = "/usr/share/rtsproxy/www" + clean_path.substr(6);
+    std::string rel_path = (std::filesystem::path("webui") / relative_path).string();
+    std::string sys_path = (std::filesystem::path("/usr/share/rtsproxy/www") / relative_path).string();
     std::string local_path = (access(rel_path.c_str(), F_OK) == 0) ? rel_path : sys_path;
     
     std::ifstream ifs(local_path, std::ios::binary);
@@ -114,8 +183,7 @@ void ApiHandle::serve_admin_file(int client_fd, const RequestInfo &info)
     {
         Logger::error("[SERVER] Admin file not found: " + local_path);
         std::string response = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
-        send(client_fd, response.c_str(), response.size(), 0);
-        close(client_fd);
+        send_response(loop, client_fd, std::move(response));
         return;
     }
     
@@ -128,12 +196,10 @@ void ApiHandle::serve_admin_file(int client_fd, const RequestInfo &info)
                          "Content-Length: " + std::to_string(content.size()) + "\r\n"
                          "Connection: close\r\n"
                          "\r\n";
-    send(client_fd, header.c_str(), header.size(), 0);
-    send(client_fd, content.c_str(), content.size(), 0);
-    close(client_fd);
+    send_response(loop, client_fd, header + content);
 }
 
-void ApiHandle::send_json_response(int client_fd, const json &j)
+void ApiHandle::send_json_response(int client_fd, const json &j, EpollLoop *loop)
 {
     std::string body;
     try
@@ -151,25 +217,24 @@ void ApiHandle::send_json_response(int client_fd, const json &j)
                          "Access-Control-Allow-Origin: *\r\n"
                          "Connection: close\r\n"
                          "\r\n";
-    send(client_fd, header.c_str(), header.size(), 0);
-    send(client_fd, body.c_str(), body.size(), 0);
-    close(client_fd);
+    send_response(loop, client_fd, header + body);
 }
 
-void ApiHandle::send_unauthorized(int client_fd)
+void ApiHandle::send_unauthorized(int client_fd, EpollLoop *loop)
 {
-    std::string response = "HTTP/1.1 401 Unauthorized\r\n"
-                           "Content-Type: text/html\r\n"
-                           "Connection: close\r\n"
-                           "\r\n"
+    std::string body =
                            "<html><head><title>401 Unauthorized</title></head>"
                            "<body style=\"font-family:sans-serif;text-align:center;padding-top:50px;\">"
                            "<h1>401 Unauthorized</h1>"
                            "<p>Invalid or missing access token.</p>"
                            "<p>Usage: <code>/admin/?token=YOUR_TOKEN</code></p>"
                            "</body></html>";
-    send(client_fd, response.c_str(), response.size(), 0);
-    close(client_fd);
+    std::string response = "HTTP/1.1 401 Unauthorized\r\n"
+                           "Content-Type: text/html\r\n"
+                           "Content-Length: " + std::to_string(body.size()) + "\r\n"
+                           "Connection: close\r\n"
+                           "\r\n" + body;
+    send_response(loop, client_fd, std::move(response));
 }
 
 std::string ApiHandle::get_mime_type(const std::string &path)

--- a/src/handlers/master_handle.cpp
+++ b/src/handlers/master_handle.cpp
@@ -9,22 +9,125 @@
 #include <string>
 #include <unistd.h>
 #include <arpa/inet.h>
+#include <algorithm>
+#include <cctype>
 
-void MasterHandle::handle(int client_fd, sockaddr_in client_addr, EpollLoop *loop, BufferPool &pool)
+namespace
+{
+constexpr size_t kMaxInitialRequestSize = 64 * 1024;
+
+void close_client(EpollLoop *loop, int client_fd)
+{
+    if (loop)
+        loop->remove(client_fd);
+    close(client_fd);
+}
+
+bool get_initial_message_size(const std::string &buffer, size_t header_end,
+                              size_t &message_size)
+{
+    const size_t headers_size = header_end + 4;
+    std::string headers = buffer.substr(0, headers_size);
+    std::transform(headers.begin(), headers.end(), headers.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    size_t body_size = 0;
+    size_t pos = headers.find("content-length:");
+    while (pos != std::string::npos &&
+           pos != 0 &&
+           !(pos >= 2 && headers[pos - 2] == '\r' && headers[pos - 1] == '\n'))
+    {
+        pos = headers.find("content-length:", pos + 1);
+    }
+    if (pos != std::string::npos)
+    {
+        pos += sizeof("content-length:") - 1;
+        while (pos < headers.size() && (headers[pos] == ' ' || headers[pos] == '\t'))
+            ++pos;
+        size_t end = headers.find_first_of("\r\n", pos);
+        try
+        {
+            size_t parsed = 0;
+            std::string value = headers.substr(pos, end - pos);
+            body_size = std::stoull(value, &parsed);
+            while (parsed < value.size() &&
+                   (value[parsed] == ' ' || value[parsed] == '\t'))
+                ++parsed;
+            if (parsed != value.size())
+                return false;
+        }
+        catch (...)
+        {
+            return false;
+        }
+    }
+
+    if (headers_size > kMaxInitialRequestSize ||
+        body_size > kMaxInitialRequestSize - headers_size)
+        return false;
+
+    message_size = headers_size + body_size;
+    return true;
+}
+}
+
+void MasterHandle::handle(int client_fd, sockaddr_in client_addr, EpollLoop *loop,
+                          BufferPool &pool, std::string &request_buffer,
+                          uint32_t events)
 {
     if (client_fd < 0) return;
 
     char buf[4096];
-    ssize_t n = recv(client_fd, buf, sizeof(buf) - 1, 0);
-    
-    if (n <= 0) {
-        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) return;
-        close(client_fd);
+    bool peer_closed = false;
+    while (true)
+    {
+        ssize_t n = recv(client_fd, buf, sizeof(buf), 0);
+        if (n > 0)
+        {
+            request_buffer.append(buf, static_cast<size_t>(n));
+            if (request_buffer.size() > kMaxInitialRequestSize)
+            {
+                Logger::warn("[MASTER] Initial request exceeds 64 KiB limit");
+                close_client(loop, client_fd);
+                return;
+            }
+            continue;
+        }
+        if (n == 0)
+        {
+            peer_closed = true;
+            break;
+        }
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+            break;
+
+        close_client(loop, client_fd);
         return;
     }
 
-    buf[n] = 0;
-    std::string req(buf, n);
+    size_t header_end = request_buffer.find("\r\n\r\n");
+    if (header_end == std::string::npos)
+    {
+        if (peer_closed || (events & (EPOLLHUP | EPOLLRDHUP | EPOLLERR)))
+            close_client(loop, client_fd);
+        return;
+    }
+
+    size_t message_size = 0;
+    if (!get_initial_message_size(request_buffer, header_end, message_size))
+    {
+        Logger::warn("[MASTER] Invalid Content-Length in initial request");
+        close_client(loop, client_fd);
+        return;
+    }
+    if (request_buffer.size() < message_size)
+    {
+        if (peer_closed)
+            close_client(loop, client_fd);
+        return;
+    }
+
+    std::string req = request_buffer;
     
     // 1. Parse the first request to identify protocol, path, and auth.
     auto info = RequestParser::parse(req);
@@ -46,8 +149,8 @@ void MasterHandle::handle(int client_fd, sockaddr_in client_addr, EpollLoop *loo
         std::string resp = info.is_http ? 
             "HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n" :
             "RTSP/1.0 401 Unauthorized\r\nCSeq: 1\r\nContent-Length: 0\r\n\r\n";
-        send(client_fd, resp.c_str(), resp.size(), 0);
-        close(client_fd);
+        send(client_fd, resp.c_str(), resp.size(), MSG_NOSIGNAL);
+        close_client(loop, client_fd);
         return;
     }
 
@@ -63,5 +166,5 @@ void MasterHandle::handle(int client_fd, sockaddr_in client_addr, EpollLoop *loo
 
     // --- No handler matched ---
     Logger::debug("[MASTER] No handler found for " + client_host + " request: " + info.clean_uri);
-    close(client_fd);
+    close_client(loop, client_fd);
 }

--- a/src/protocol/rtp_pipeline.cpp
+++ b/src/protocol/rtp_pipeline.cpp
@@ -40,7 +40,9 @@ bool RtpPipeline::get_payload_offset(const uint8_t *buf, size_t len, size_t &off
     size_t payload_offset = 12 + (buf[0] & 0x0F) * 4;
     if (unlikely(buf[0] & 0x10)) { // Extension
         if (unlikely(payload_offset + 4 > len)) return false;
-        uint16_t ext_len = ntohs(*reinterpret_cast<const uint16_t *>(buf + payload_offset + 2));
+        uint16_t wire_ext_len = 0;
+        memcpy(&wire_ext_len, buf + payload_offset + 2, sizeof(wire_ext_len));
+        uint16_t ext_len = ntohs(wire_ext_len);
         payload_offset += 4 + 4 * ext_len;
     }
     

--- a/src/protocol/rtsp_parser.cpp
+++ b/src/protocol/rtsp_parser.cpp
@@ -1,11 +1,14 @@
 #include "protocol/rtsp_parser.h"
 #include "core/logger.h"
 #include "common/rtsp_ctx.h"
+#include "utils/dns_resolver.h"
 #include <unistd.h>
 #include <cstring>
 #include <sstream>
 #include <algorithm>
 #include <cctype>
+#include <limits>
+#include <arpa/inet.h>
 
 rtspParser::rtspParser() {}
 rtspParser::~rtspParser() {}
@@ -117,12 +120,9 @@ void rtspParser::SDP::parseBandwidth(const std::string &line, rtspCtx &ctx)
 
 int rtspParser::parse_server_ports(const std::string &resp, rtspCtx &ctx)
 {
-    size_t pos = resp.find("Transport:");
-    if (pos == std::string::npos)
+    std::string transport_ = extract_header_value(resp, "Transport");
+    if (transport_.empty())
         return -1;
-
-    size_t end = resp.find("\r\n", pos);
-    std::string transport_ = resp.substr(pos, end - pos);
 
     size_t sp_pos = transport_.find("server_port=");
     if (sp_pos != std::string::npos)
@@ -133,8 +133,13 @@ int rtspParser::parse_server_ports(const std::string &resp, rtspCtx &ctx)
         {
             try
             {
-                ctx.server_rtp_port = std::stoi(transport_.substr(sp_pos, dash - sp_pos));
-                ctx.server_rtcp_port = std::stoi(transport_.substr(dash + 1));
+                int rtp_port = std::stoi(transport_.substr(sp_pos, dash - sp_pos));
+                int rtcp_port = std::stoi(transport_.substr(dash + 1));
+                if (rtp_port < 1 || rtp_port > 65535 ||
+                    rtcp_port < 1 || rtcp_port > 65535)
+                    return -1;
+                ctx.server_rtp_port = static_cast<uint16_t>(rtp_port);
+                ctx.server_rtcp_port = static_cast<uint16_t>(rtcp_port);
                 return 0;
             }
             catch (...)
@@ -155,8 +160,13 @@ int rtspParser::parse_server_ports(const std::string &resp, rtspCtx &ctx)
             // The caller (RTSPToHttpClient) will check for "interleaved" in the string anyway
             try
             {
-                ctx.server_rtp_port = std::stoi(transport_.substr(int_pos, dash - int_pos));
-                ctx.server_rtcp_port = std::stoi(transport_.substr(dash + 1));
+                int rtp_channel = std::stoi(transport_.substr(int_pos, dash - int_pos));
+                int rtcp_channel = std::stoi(transport_.substr(dash + 1));
+                if (rtp_channel < 0 || rtp_channel > 255 ||
+                    rtcp_channel < 0 || rtcp_channel > 255)
+                    return -1;
+                ctx.server_rtp_port = static_cast<uint16_t>(rtp_channel);
+                ctx.server_rtcp_port = static_cast<uint16_t>(rtcp_channel);
                 return 0;
             }
             catch (...)
@@ -171,27 +181,25 @@ int rtspParser::parse_server_ports(const std::string &resp, rtspCtx &ctx)
 
 int rtspParser::get_content_length(const std::string &resp)
 {
-    size_t pos = resp.find("Content-Length:");
-    if (pos == std::string::npos)
-        pos = resp.find("Content-length:");
-    if (pos == std::string::npos)
-        return 0;
-
-    pos += 15;
-    while (pos < resp.size() && (resp[pos] == ' ' || resp[pos] == '\t'))
-        ++pos;
-
-    size_t end = resp.find_first_of("\r\n", pos);
-    if (end == std::string::npos)
+    std::string value = extract_header_value(resp, "Content-Length");
+    if (value.empty())
         return 0;
 
     try
     {
-        return std::stoi(resp.substr(pos, end - pos));
+        size_t parsed = 0;
+        long long length = std::stoll(value, &parsed);
+        while (parsed < value.size() &&
+               (value[parsed] == ' ' || value[parsed] == '\t'))
+            ++parsed;
+        if (parsed != value.size() || length < 0 ||
+            length > std::numeric_limits<int>::max())
+            return -1;
+        return static_cast<int>(length);
     }
     catch (...)
     {
-        return 0;
+        return -1;
     }
 }
 
@@ -204,14 +212,11 @@ int rtspParser::parse_status_code(const std::string &resp)
 
 int rtspParser::parse_session_id(const std::string &resp, rtspCtx &ctx)
 {
-    size_t pos = resp.find("Session:");
-    if (pos == std::string::npos)
+    std::string session = extract_header_value(resp, "Session");
+    if (session.empty())
         return -1;
-    pos += 8;
-    while (pos < resp.size() && (resp[pos] == ' ' || resp[pos] == '\t'))
-        ++pos;
-    size_t end = resp.find_first_of(";\r\n", pos);
-    ctx.session_id = resp.substr(pos, end - pos);
+    size_t end = session.find(';');
+    ctx.session_id = session.substr(0, end);
     return 0;
 }
 
@@ -246,7 +251,11 @@ int rtspParser::parse_url(const std::string &url, rtspCtx &ctx)
         if (colon != std::string::npos)
         {
             ctx.server_ip = hostport.substr(0, colon);
-            ctx.server_rtsp_port = std::stoi(hostport.substr(colon + 1));
+            size_t parsed = 0;
+            int port = std::stoi(hostport.substr(colon + 1), &parsed);
+            if (parsed != hostport.size() - colon - 1 || port < 1 || port > 65535)
+                return -1;
+            ctx.server_rtsp_port = static_cast<uint16_t>(port);
         }
         else
         {
@@ -258,6 +267,18 @@ int rtspParser::parse_url(const std::string &url, rtspCtx &ctx)
     {
         Logger::error("[RTSP] Failed to parse port in URL: " + clean_url);
         return -1;
+    }
+
+    struct in_addr numeric_addr{};
+    if (inet_pton(AF_INET, ctx.server_ip.c_str(), &numeric_addr) != 1)
+    {
+        auto addresses = DNSResolver::resolve_ipv4(ctx.server_ip);
+        if (addresses.empty())
+        {
+            Logger::error("[RTSP] Failed to resolve host in URL: " + ctx.server_ip);
+            return -1;
+        }
+        ctx.server_ip = addresses.front();
     }
 
     ctx.path = (slash != std::string::npos) ? clean_url.substr(slash) : "/";
@@ -272,9 +293,17 @@ std::string rtspParser::extract_header_value(const std::string &msg, const std::
     std::transform(lower_msg.begin(), lower_msg.end(), lower_msg.begin(), [](unsigned char c) { return std::tolower(c); });
     std::transform(lower_hdr.begin(), lower_hdr.end(), lower_hdr.begin(), [](unsigned char c) { return std::tolower(c); });
 
-    size_t pos = lower_msg.find(lower_hdr + ":");
-    if (pos == std::string::npos)
-        return {};
+    const std::string needle = lower_hdr + ":";
+    size_t pos = 0;
+    while (true)
+    {
+        pos = lower_msg.find(needle, pos);
+        if (pos == std::string::npos)
+            return {};
+        if (pos == 0 || (pos >= 2 && msg[pos - 2] == '\r' && msg[pos - 1] == '\n'))
+            break;
+        pos += needle.size();
+    }
     pos += header_name.size() + 1;
     while (pos < msg.size() && (msg[pos] == ' ' || msg[pos] == '\t'))
         ++pos;

--- a/src/utils/blacklist_checker.cpp
+++ b/src/utils/blacklist_checker.cpp
@@ -48,7 +48,19 @@ bool BlacklistChecker::match_cidr(const std::string &ip, const std::string &cidr
     if (slash_pos == std::string::npos) return ip == cidr;
 
     std::string base_ip_str = cidr.substr(0, slash_pos);
-    int bits = std::stoi(cidr.substr(slash_pos + 1));
+    int bits = 0;
+    try
+    {
+        size_t parsed = 0;
+        std::string bits_str = cidr.substr(slash_pos + 1);
+        bits = std::stoi(bits_str, &parsed);
+        if (parsed != bits_str.size() || bits < 0 || bits > 32)
+            return false;
+    }
+    catch (...)
+    {
+        return false;
+    }
 
     struct in_addr base_addr, target_addr;
     if (inet_pton(AF_INET, base_ip_str.c_str(), &base_addr) != 1) return false;

--- a/src/utils/socket_helper.cpp
+++ b/src/utils/socket_helper.cpp
@@ -7,6 +7,8 @@
 #include <unistd.h>
 #include <string>
 #include <random>
+#include <netdb.h>
+#include <cstring>
 
 static void optimize_udp_buffer(int fd)
 {
@@ -45,9 +47,15 @@ int create_listen_socket(int port, const std::string &iface)
     addr.sin_port = htons(port);
 
     if (bind(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+    {
+        close(sockfd);
         return -1;
+    }
     if (listen(sockfd, 5) < 0)
+    {
+        close(sockfd);
         return -1;
+    }
 
     fcntl(sockfd, F_SETFL, O_NONBLOCK);
 
@@ -56,29 +64,51 @@ int create_listen_socket(int port, const std::string &iface)
 
 int create_nonblocking_tcp(const std::string &ip, uint16_t port, const std::string &iface = "")
 {
-    int sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    addrinfo hints{};
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
 
-    fcntl(sockfd, F_SETFL, O_NONBLOCK);
-
-    if (!iface.empty())
-    {
-        if (setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE, iface.c_str(), iface.length()) < 0)
-        {
-            close(sockfd);
-            return -1;
-        }
-    }
-
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
-    inet_pton(AF_INET, ip.c_str(), &addr.sin_addr);
-
-    if (connect(sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0 && errno != EINPROGRESS)
+    addrinfo *results = nullptr;
+    std::string service = std::to_string(port);
+    if (getaddrinfo(ip.c_str(), service.c_str(), &hints, &results) != 0)
         return -1;
 
-    set_tcp_nodelay(sockfd);
-    return sockfd;
+    int connected_fd = -1;
+    for (addrinfo *entry = results; entry != nullptr; entry = entry->ai_next)
+    {
+        int sockfd = socket(entry->ai_family, entry->ai_socktype, entry->ai_protocol);
+        if (sockfd < 0)
+            continue;
+
+        int flags = fcntl(sockfd, F_GETFL, 0);
+        if (flags < 0 || fcntl(sockfd, F_SETFL, flags | O_NONBLOCK) < 0)
+        {
+            close(sockfd);
+            continue;
+        }
+
+        if (!iface.empty() &&
+            setsockopt(sockfd, SOL_SOCKET, SO_BINDTODEVICE,
+                       iface.c_str(), iface.length()) < 0)
+        {
+            close(sockfd);
+            continue;
+        }
+
+        if (connect(sockfd, entry->ai_addr, entry->ai_addrlen) == 0 ||
+            errno == EINPROGRESS)
+        {
+            connected_fd = sockfd;
+            break;
+        }
+
+        close(sockfd);
+    }
+
+    freeaddrinfo(results);
+    if (connected_fd >= 0)
+        set_tcp_nodelay(connected_fd);
+    return connected_fd;
 }
 
 uint16_t get_random_port()
@@ -143,12 +173,17 @@ int bind_udp_socket(int &fd, const uint16_t &port, const std::string &iface = ""
         if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, iface.c_str(), iface.length()) < 0)
         {
             close(fd);
+            fd = -1;
             return -1;
         }
     }
 
     if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0)
+    {
+        close(fd);
+        fd = -1;
         return -1;
+    }
 
     optimize_udp_buffer(fd);
     return 0;

--- a/src/utils/url_rewriter.cpp
+++ b/src/utils/url_rewriter.cpp
@@ -51,7 +51,15 @@ std::string URLRewriter::shiftTime(const std::string &time_str, int shift_hours)
         strftime(buffer, sizeof(buffer), "%Y%m%d%H%M%S", new_timeinfo);
         return std::string(buffer);
     } else if (time_str.length() <= 10) {
-        time_t timestamp = std::stoll(time_str);
+        time_t timestamp;
+        try {
+            size_t parsed = 0;
+            long long value = std::stoll(time_str, &parsed);
+            if (parsed != time_str.size()) return time_str;
+            timestamp = static_cast<time_t>(value);
+        } catch (...) {
+            return time_str;
+        }
         timestamp += shift_hours * 3600;
         struct tm *new_timeinfo = gmtime(&timestamp);
         char buffer[16];

--- a/webui/index.html
+++ b/webui/index.html
@@ -1,109 +1,245 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>RTSProxy Dashboard</title>
+    <meta name="color-scheme" content="dark">
+    <meta name="theme-color" content="#07110f">
+    <title>RTSProxy · 实时控制台</title>
     <link rel="stylesheet" href="style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=JetBrains+Mono&display=swap" rel="stylesheet">
 </head>
 <body>
-    <div class="container">
-        <header>
-            <div class="title-group">
-                <h1>RTSProxy Dashboard</h1>
-            </div>
-            <div class="status-badge" id="server-status">
-                <span class="dot"></span> ONLINE
+    <div class="ambient ambient-top" aria-hidden="true"></div>
+    <div class="ambient ambient-side" aria-hidden="true"></div>
+
+    <div class="app-shell">
+        <header class="topbar">
+            <a class="brand" id="brand-home" href="/admin/" aria-label="RTSProxy 首页">
+                <span class="brand-mark" aria-hidden="true">
+                    <svg viewBox="0 0 32 32" role="img">
+                        <path d="M7 10.5c5.6-4.7 12.4-4.7 18 0"></path>
+                        <path d="M10.5 14.5c3.4-2.8 7.6-2.8 11 0"></path>
+                        <path d="M13.8 18.5c1.4-1.1 3-1.1 4.4 0"></path>
+                        <circle cx="16" cy="23" r="2.3"></circle>
+                    </svg>
+                </span>
+                <span>
+                    <strong>RTSProxy</strong>
+                    <small>STREAM GATEWAY</small>
+                </span>
+            </a>
+
+            <div class="topbar-actions">
+                <div class="sync-info">
+                    <span>最后更新</span>
+                    <strong id="last-updated">正在连接</strong>
+                </div>
+                <button class="icon-button" id="refresh-now" type="button" aria-label="立即刷新" title="立即刷新">
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M20 11a8.1 8.1 0 0 0-15.5-2M4 4v5h5"></path>
+                        <path d="M4 13a8.1 8.1 0 0 0 15.5 2M20 20v-5h-5"></path>
+                    </svg>
+                </button>
+                <div class="status-pill connecting" id="server-status" role="status" aria-live="polite">
+                    <span class="status-dot"></span>
+                    <span id="server-status-text">连接中</span>
+                </div>
             </div>
         </header>
 
-        <!-- STATUS ROW 1: Performance -->
-        <div class="status-bar">
-            <div class="stat-item">
-                <span class="label">Up Bandwidth</span>
-                <span class="value" id="up-bandwidth">0 Mbps</span>
-            </div>
-            <div class="stat-item">
-                <span class="label">Down Bandwidth</span>
-                <span class="value" id="down-bandwidth">0 Mbps</span>
-            </div>
-            <div class="stat-item">
-                <span class="label">Up Traffic</span>
-                <span class="value" id="up-traffic">0 B</span>
-            </div>
-            <div class="stat-item">
-                <span class="label">Down Traffic</span>
-                <span class="value" id="down-traffic">0 B</span>
-            </div>
-            <div class="stat-item">
-                <span class="label">Clients</span>
-                <span class="value" id="active-clients">0</span>
-            </div>
-        </div>
-
-        <!-- STATUS ROW 2: Memory -->
-        <div class="status-bar">
-            <div class="stat-item">
-                <span class="label">Used Buffers</span>
-                <span class="value" id="used-count">0</span>
-            </div>
-            <div class="stat-item">
-                <span class="label">Total Buffers</span>
-                <span class="value" id="total-buffers">0</span>
-            </div>
-            <div class="stat-item">
-                <span class="label">Total RAM</span>
-                <span class="value" id="total-memory">0 MB</span>
-            </div>
-        </div>
-
-        <main class="main-content">
-            <!-- LEFT: Active Sessions -->
-            <section class="sessions-area">
-                <div class="card-header">
-                    <h2>Active Sessions</h2>
+        <main>
+            <section class="page-heading">
+                <div>
+                    <p class="eyebrow">REALTIME MONITOR</p>
+                    <h1>流媒体运行概览</h1>
+                    <p class="heading-copy">实时观察代理流量、客户端会话与缓冲池状态。</p>
                 </div>
-                <div class="table-container">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Downstream</th>
-                                <th>Upstream</th>
-                                <th>Type</th>
-                                <th>Up Bitrate</th>
-                                <th>Down Bitrate</th>
-                                <th>Protocol</th>
-                                <th>Duration</th>
-                            </tr>
-                        </thead>
-                        <tbody id="sessions-body">
-                            <!-- JS populated -->
-                        </tbody>
-                    </table>
-                </div>
+                <div class="live-label"><span></span> LIVE DATA</div>
             </section>
 
-            <!-- RIGHT: Live Logs -->
-            <section class="logs-area">
-                <div class="card-header">
-                    <h2>Live Logs</h2>
-                    <div class="controls">
-                        <select id="log-level-select">
-                            <option value="0">DEBUG</option>
-                            <option value="1" selected>INFO</option>
-                            <option value="2">WARN</option>
-                            <option value="3">ERROR</option>
-                        </select>
-                        <button id="clear-logs">Clear</button>
+            <section class="metric-grid" aria-label="核心指标">
+                <article class="metric-card metric-up">
+                    <div class="metric-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24"><path d="M12 19V5M6.5 10.5 12 5l5.5 5.5"></path></svg>
                     </div>
-                </div>
-                <div class="log-container" id="log-display">
-                    <!-- Logs will appear here -->
-                </div>
+                    <div class="metric-content">
+                        <span class="metric-label">上行带宽</span>
+                        <strong class="metric-value" id="up-bandwidth">0 bps</strong>
+                        <span class="metric-meta">累计 <b id="up-traffic">0 B</b></span>
+                    </div>
+                </article>
+
+                <article class="metric-card metric-down">
+                    <div class="metric-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24"><path d="M12 5v14M17.5 13.5 12 19l-5.5-5.5"></path></svg>
+                    </div>
+                    <div class="metric-content">
+                        <span class="metric-label">下行带宽</span>
+                        <strong class="metric-value" id="down-bandwidth">0 bps</strong>
+                        <span class="metric-meta">累计 <b id="down-traffic">0 B</b></span>
+                    </div>
+                </article>
+
+                <article class="metric-card metric-clients">
+                    <div class="metric-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <path d="M16 19v-1.4a3.6 3.6 0 0 0-3.6-3.6H7.6A3.6 3.6 0 0 0 4 17.6V19"></path>
+                            <circle cx="10" cy="7.5" r="3.5"></circle>
+                            <path d="M17 10.5a3 3 0 0 1 3 3V15"></path>
+                        </svg>
+                    </div>
+                    <div class="metric-content">
+                        <span class="metric-label">活跃客户端</span>
+                        <strong class="metric-value" id="active-clients">0</strong>
+                        <span class="metric-meta"><i class="mini-pulse"></i> 当前连接数</span>
+                    </div>
+                </article>
+
+                <article class="metric-card metric-buffer">
+                    <div class="metric-icon" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <rect x="4" y="5" width="16" height="5" rx="2"></rect>
+                            <rect x="4" y="14" width="16" height="5" rx="2"></rect>
+                            <path d="M8 7.5h.01M8 16.5h.01"></path>
+                        </svg>
+                    </div>
+                    <div class="metric-content metric-buffer-content">
+                        <span class="metric-label">缓冲池占用</span>
+                        <strong class="metric-value" id="buffer-usage">0%</strong>
+                        <span class="metric-meta" id="buffer-summary">0 / 0 buffers</span>
+                    </div>
+                    <div class="metric-progress" aria-hidden="true"><span id="buffer-progress"></span></div>
+                </article>
+            </section>
+
+            <section class="insight-grid">
+                <article class="panel traffic-panel">
+                    <div class="panel-header">
+                        <div>
+                            <p class="panel-kicker">NETWORK</p>
+                            <h2>实时吞吐趋势</h2>
+                        </div>
+                        <div class="chart-legend" aria-label="图例">
+                            <span><i class="legend-up"></i>上行</span>
+                            <span><i class="legend-down"></i>下行</span>
+                        </div>
+                    </div>
+                    <div class="chart-summary">
+                        <div><span>当前上行</span><strong id="chart-up-value">0 bps</strong></div>
+                        <div><span>当前下行</span><strong id="chart-down-value">0 bps</strong></div>
+                        <div class="chart-scale"><span>图表峰值</span><strong id="chart-max-value">1 Mbps</strong></div>
+                    </div>
+                    <div class="chart-wrap" aria-label="最近 60 秒带宽趋势图">
+                        <svg class="traffic-chart" viewBox="0 0 600 180" preserveAspectRatio="none" role="img">
+                            <defs>
+                                <linearGradient id="up-area-gradient" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="#52e0b7" stop-opacity=".3"></stop>
+                                    <stop offset="100%" stop-color="#52e0b7" stop-opacity="0"></stop>
+                                </linearGradient>
+                                <linearGradient id="down-area-gradient" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="#6d9dff" stop-opacity=".25"></stop>
+                                    <stop offset="100%" stop-color="#6d9dff" stop-opacity="0"></stop>
+                                </linearGradient>
+                            </defs>
+                            <g class="chart-grid" aria-hidden="true">
+                                <line x1="0" y1="10" x2="600" y2="10"></line>
+                                <line x1="0" y1="62.5" x2="600" y2="62.5"></line>
+                                <line x1="0" y1="115" x2="600" y2="115"></line>
+                                <line x1="0" y1="167.5" x2="600" y2="167.5"></line>
+                            </g>
+                            <path id="chart-up-area" class="chart-area up-area" d=""></path>
+                            <path id="chart-down-area" class="chart-area down-area" d=""></path>
+                            <polyline id="chart-up-line" class="chart-line up-line" points=""></polyline>
+                            <polyline id="chart-down-line" class="chart-line down-line" points=""></polyline>
+                        </svg>
+                        <div class="chart-axis"><span>60 秒前</span><span>现在</span></div>
+                    </div>
+                </article>
+
+                <article class="panel pool-panel">
+                    <div class="panel-header">
+                        <div>
+                            <p class="panel-kicker">MEMORY POOL</p>
+                            <h2>缓冲池状态</h2>
+                        </div>
+                        <span class="health-chip" id="pool-health">健康</span>
+                    </div>
+                    <div class="pool-content">
+                        <div class="buffer-gauge" id="buffer-gauge" role="img" aria-label="缓冲池占用 0%">
+                            <div>
+                                <strong id="gauge-value">0%</strong>
+                                <span>已占用</span>
+                            </div>
+                        </div>
+                        <dl class="pool-stats">
+                            <div><dt>正在使用</dt><dd id="used-count">0</dd></div>
+                            <div><dt>可用缓冲</dt><dd id="available-count">0</dd></div>
+                            <div><dt>峰值占用</dt><dd id="peak-count">0</dd></div>
+                            <div><dt>内存容量</dt><dd id="total-memory">0 B</dd></div>
+                        </dl>
+                    </div>
+                </article>
+            </section>
+
+            <section class="workspace-grid">
+                <article class="panel sessions-panel">
+                    <div class="panel-header">
+                        <div>
+                            <p class="panel-kicker">CONNECTIONS</p>
+                            <h2>活动会话 <span class="count-badge" id="session-count">0</span></h2>
+                        </div>
+                        <span class="panel-note">每秒自动刷新</span>
+                    </div>
+                    <div class="table-container">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>客户端</th>
+                                    <th>上游节点</th>
+                                    <th>代理模式</th>
+                                    <th>实时速率</th>
+                                    <th>传输</th>
+                                    <th>持续时间</th>
+                                </tr>
+                            </thead>
+                            <tbody id="sessions-body"></tbody>
+                        </table>
+                    </div>
+                </article>
+
+                <article class="panel logs-panel">
+                    <div class="panel-header logs-header">
+                        <div>
+                            <p class="panel-kicker">EVENT STREAM</p>
+                            <h2>运行日志</h2>
+                        </div>
+                        <div class="log-actions">
+                            <label class="log-search">
+                                <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="6"></circle><path d="m16 16 4 4"></path></svg>
+                                <input id="log-search" type="search" placeholder="搜索日志" autocomplete="off" aria-label="搜索日志">
+                            </label>
+                            <select id="log-level-select" aria-label="最低日志等级">
+                                <option value="0">DEBUG+</option>
+                                <option value="1" selected>INFO+</option>
+                                <option value="2">WARN+</option>
+                                <option value="3">ERROR</option>
+                            </select>
+                            <button class="text-button" id="pause-logs" type="button">暂停</button>
+                            <button class="text-button danger" id="clear-logs" type="button">清空</button>
+                        </div>
+                    </div>
+                    <div class="log-container" id="log-display" aria-live="polite"></div>
+                </article>
             </section>
         </main>
+
+        <footer>
+            <span>RTSProxy Control Plane</span>
+            <span class="footer-divider"></span>
+            <span>WebUI 2.0</span>
+        </footer>
     </div>
+
     <script src="main.js"></script>
 </body>
 </html>

--- a/webui/main.js
+++ b/webui/main.js
@@ -1,178 +1,520 @@
+'use strict';
+
 class Dashboard {
     constructor() {
         this.statusEndpoint = '/api/status';
         this.logEndpoint = '/api/logs';
-        this.lastLogTimestamp = '';
+        this.statusInFlight = false;
+        this.logsInFlight = false;
+        this.logsPaused = false;
+        this.serverLogs = null;
+        this.visibleLogs = [];
+        this.historyLength = 60;
+        this.upHistory = new Array(this.historyLength).fill(0);
+        this.downHistory = new Array(this.historyLength).fill(0);
 
-        // DOM Elements
         this.elements = {
+            brandHome: document.getElementById('brand-home'),
+            serverStatus: document.getElementById('server-status'),
+            serverStatusText: document.getElementById('server-status-text'),
+            lastUpdated: document.getElementById('last-updated'),
+            refreshButton: document.getElementById('refresh-now'),
             upBandwidth: document.getElementById('up-bandwidth'),
             downBandwidth: document.getElementById('down-bandwidth'),
             upTraffic: document.getElementById('up-traffic'),
             downTraffic: document.getElementById('down-traffic'),
             activeClients: document.getElementById('active-clients'),
+            bufferUsage: document.getElementById('buffer-usage'),
+            bufferSummary: document.getElementById('buffer-summary'),
+            bufferProgress: document.getElementById('buffer-progress'),
+            gauge: document.getElementById('buffer-gauge'),
+            gaugeValue: document.getElementById('gauge-value'),
+            poolHealth: document.getElementById('pool-health'),
             usedBuffers: document.getElementById('used-count'),
-            totalBuffers: document.getElementById('total-buffers'),
+            availableBuffers: document.getElementById('available-count'),
+            peakBuffers: document.getElementById('peak-count'),
             totalMemory: document.getElementById('total-memory'),
+            chartUpValue: document.getElementById('chart-up-value'),
+            chartDownValue: document.getElementById('chart-down-value'),
+            chartMaxValue: document.getElementById('chart-max-value'),
+            chartUpLine: document.getElementById('chart-up-line'),
+            chartDownLine: document.getElementById('chart-down-line'),
+            chartUpArea: document.getElementById('chart-up-area'),
+            chartDownArea: document.getElementById('chart-down-area'),
             sessionsBody: document.getElementById('sessions-body'),
+            sessionCount: document.getElementById('session-count'),
             logDisplay: document.getElementById('log-display'),
+            logSearch: document.getElementById('log-search'),
             logLevelSelect: document.getElementById('log-level-select'),
-            clearLogsBtn: document.getElementById('clear-logs'),
-            serverStatus: document.getElementById('server-status')
+            pauseLogsButton: document.getElementById('pause-logs'),
+            clearLogsButton: document.getElementById('clear-logs')
         };
 
         this.init();
     }
 
     init() {
-        // Load saved log level
-        const savedLevel = localStorage.getItem('logLevel');
-        if (savedLevel && this.elements.logLevelSelect) {
+        if (this.elements.brandHome) {
+            this.elements.brandHome.href = this.endpointUrl('/admin/');
+        }
+
+        const savedLevel = localStorage.getItem('rtsproxy.logLevel');
+        if (savedLevel !== null && this.elements.logLevelSelect) {
             this.elements.logLevelSelect.value = savedLevel;
         }
 
-        if (this.elements.clearLogsBtn) {
-            this.elements.clearLogsBtn.onclick = () => this.elements.logDisplay.innerHTML = '';
-        }
-        if (this.elements.logLevelSelect) {
-            this.elements.logLevelSelect.onchange = () => this.changeLogLevel();
-        }
-        
-        // Refresh loops
+        this.elements.refreshButton?.addEventListener('click', () => {
+            this.refresh();
+            if (!this.logsPaused) this.fetchLogs();
+        });
+
+        this.elements.logLevelSelect?.addEventListener('change', () => {
+            localStorage.setItem('rtsproxy.logLevel', this.elements.logLevelSelect.value);
+            this.renderLogs();
+        });
+
+        this.elements.logSearch?.addEventListener('input', () => this.renderLogs());
+        this.elements.pauseLogsButton?.addEventListener('click', () => this.toggleLogs());
+        this.elements.clearLogsButton?.addEventListener('click', () => {
+            this.visibleLogs = [];
+            this.renderLogs();
+        });
+
+        document.addEventListener('visibilitychange', () => {
+            if (!document.hidden) {
+                this.refresh();
+                if (!this.logsPaused) this.fetchLogs();
+            }
+        });
+
+        this.renderEmptySessions();
+        this.renderLogs();
+        this.updateChart();
         this.refresh();
-        setInterval(() => this.refresh(), 1000);
-        setInterval(() => this.fetchLogs(), 500);
+        this.fetchLogs();
+
+        window.setInterval(() => {
+            if (!document.hidden) this.refresh();
+        }, 1000);
+        window.setInterval(() => {
+            if (!document.hidden && !this.logsPaused) this.fetchLogs();
+        }, 750);
     }
 
-    async changeLogLevel() {
-        const level = this.elements.logLevelSelect.value;
-        localStorage.setItem('logLevel', level);
-        // Backend API call removed - filtering is handled locally in updateLogs
+    endpointUrl(endpoint) {
+        const url = new URL(endpoint, window.location.origin);
+        const token = new URLSearchParams(window.location.search).get('token');
+        if (token) url.searchParams.set('token', token);
+        return url.toString();
+    }
+
+    async fetchJson(endpoint, timeoutMs = 4500) {
+        const controller = new AbortController();
+        const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
+        try {
+            const response = await fetch(this.endpointUrl(endpoint), {
+                cache: 'no-store',
+                headers: { Accept: 'application/json' },
+                signal: controller.signal
+            });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return await response.json();
+        } finally {
+            window.clearTimeout(timeout);
+        }
     }
 
     async refresh() {
+        if (this.statusInFlight) return;
+        this.statusInFlight = true;
+        this.elements.refreshButton?.classList.add('loading');
+
         try {
-            const urlParams = new URLSearchParams(window.location.search);
-            const token = urlParams.get('token');
-            const fetchUrl = token ? `${this.statusEndpoint}?token=${token}` : this.statusEndpoint;
-            
-            const response = await fetch(fetchUrl);
-            if (!response.ok) throw new Error();
-            
-            const data = await response.json();
+            const data = await this.fetchJson(this.statusEndpoint);
             this.updateStatus(data);
-            this.updateSessions(data.clients || []);
-            
-            this.elements.serverStatus.innerHTML = '<span class="dot"></span> ONLINE';
-            this.elements.serverStatus.style.color = '#34d399';
-        } catch (e) {
-            this.elements.serverStatus.innerHTML = '<span class="dot" style="background:#ef4444"></span> OFFLINE';
-            this.elements.serverStatus.style.color = '#ef4444';
+            this.updateSessions(Array.isArray(data.clients) ? data.clients : []);
+            this.setConnectionState('online');
+        } catch (error) {
+            this.setConnectionState('offline');
+        } finally {
+            this.statusInFlight = false;
+            this.elements.refreshButton?.classList.remove('loading');
+        }
+    }
+
+    setConnectionState(state) {
+        if (!this.elements.serverStatus || !this.elements.serverStatusText) return;
+        this.elements.serverStatus.classList.remove('online', 'offline', 'connecting');
+        this.elements.serverStatus.classList.add(state);
+
+        if (state === 'online') {
+            this.elements.serverStatusText.textContent = '运行中';
+            this.elements.lastUpdated.textContent = new Date().toLocaleTimeString('zh-CN', {
+                hour12: false,
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit'
+            });
+        } else {
+            this.elements.serverStatusText.textContent = '已离线';
+            this.elements.lastUpdated.textContent = '连接中断';
         }
     }
 
     updateStatus(data) {
-        const stats = data.stats || {};
-        const pool = data.pool || {};
-        
-        const upMbps = (stats.up_bandwidth || 0) * 8 / 1000000;
-        const downMbps = (stats.down_bandwidth || 0) * 8 / 1000000;
-        this.elements.upBandwidth.innerText = `${upMbps.toFixed(2)} Mbps`;
-        this.elements.downBandwidth.innerText = `${downMbps.toFixed(2)} Mbps`;
-        
-        this.elements.upTraffic.innerText = this.formatBytes(stats.up_traffic || 0);
-        this.elements.downTraffic.innerText = this.formatBytes(stats.down_traffic || 0);
-        
-        this.elements.activeClients.innerText = stats.active_clients || 0;
-        this.elements.usedBuffers.innerText = `${pool.used || 0} (Peak: ${pool.peak || 0})`;
-        this.elements.totalBuffers.innerText = pool.allocated || 0;
-        
-        const totalMemoryMB = (pool.total_bytes || 0) / (1024 * 1024);
-        this.elements.totalMemory.innerText = `${totalMemoryMB.toFixed(1)} MB`;
+        const stats = data?.stats && typeof data.stats === 'object' ? data.stats : {};
+        const pool = data?.pool && typeof data.pool === 'object' ? data.pool : {};
+        const upBitsPerSecond = this.toNumber(stats.up_bandwidth) * 8;
+        const downBitsPerSecond = this.toNumber(stats.down_bandwidth) * 8;
+
+        this.setText(this.elements.upBandwidth, this.formatBitRate(upBitsPerSecond));
+        this.setText(this.elements.downBandwidth, this.formatBitRate(downBitsPerSecond));
+        this.setText(this.elements.chartUpValue, this.formatBitRate(upBitsPerSecond));
+        this.setText(this.elements.chartDownValue, this.formatBitRate(downBitsPerSecond));
+        this.setText(this.elements.upTraffic, this.formatBytes(this.toNumber(stats.up_traffic)));
+        this.setText(this.elements.downTraffic, this.formatBytes(this.toNumber(stats.down_traffic)));
+        this.setText(this.elements.activeClients, this.formatInteger(stats.active_clients));
+
+        const allocated = Math.max(0, this.toNumber(pool.allocated));
+        const reportedUsed = Math.max(0, this.toNumber(pool.used));
+        const used = allocated > 0 ? Math.min(reportedUsed, allocated) : reportedUsed;
+        const available = Math.max(0, this.toNumber(pool.available));
+        const peak = Math.max(0, this.toNumber(pool.peak));
+        const usage = allocated > 0 ? Math.min(100, (used / allocated) * 100) : 0;
+
+        this.setText(this.elements.bufferUsage, `${usage.toFixed(1)}%`);
+        this.setText(this.elements.bufferSummary, `${this.formatInteger(used)} / ${this.formatInteger(allocated)} buffers`);
+        if (this.elements.bufferProgress) this.elements.bufferProgress.style.width = `${usage}%`;
+        this.setText(this.elements.gaugeValue, `${Math.round(usage)}%`);
+        if (this.elements.gauge) {
+            this.elements.gauge.style.setProperty('--gauge-value', `${usage * 3.6}deg`);
+            this.elements.gauge.setAttribute('aria-label', `缓冲池占用 ${usage.toFixed(1)}%`);
+        }
+        this.setText(this.elements.usedBuffers, this.formatInteger(used));
+        this.setText(this.elements.availableBuffers, this.formatInteger(available));
+        this.setText(this.elements.peakBuffers, this.formatInteger(peak));
+        this.setText(this.elements.totalMemory, this.formatBytes(this.toNumber(pool.total_bytes)));
+        this.updatePoolHealth(usage);
+
+        this.upHistory.shift();
+        this.upHistory.push(upBitsPerSecond);
+        this.downHistory.shift();
+        this.downHistory.push(downBitsPerSecond);
+        this.updateChart();
+    }
+
+    updatePoolHealth(usage) {
+        if (!this.elements.poolHealth) return;
+        this.elements.poolHealth.classList.remove('warning', 'critical');
+        if (usage >= 85) {
+            this.elements.poolHealth.textContent = '压力较高';
+            this.elements.poolHealth.classList.add('critical');
+        } else if (usage >= 65) {
+            this.elements.poolHealth.textContent = '需要关注';
+            this.elements.poolHealth.classList.add('warning');
+        } else {
+            this.elements.poolHealth.textContent = '健康';
+        }
+    }
+
+    updateChart() {
+        const observedMax = Math.max(...this.upHistory, ...this.downHistory, 0);
+        const scaleMax = this.niceScale(observedMax);
+        const upPoints = this.chartPoints(this.upHistory, scaleMax);
+        const downPoints = this.chartPoints(this.downHistory, scaleMax);
+
+        this.elements.chartUpLine?.setAttribute('points', upPoints);
+        this.elements.chartDownLine?.setAttribute('points', downPoints);
+        this.elements.chartUpArea?.setAttribute('d', this.areaPath(upPoints));
+        this.elements.chartDownArea?.setAttribute('d', this.areaPath(downPoints));
+        this.setText(this.elements.chartMaxValue, this.formatBitRate(scaleMax));
+    }
+
+    chartPoints(values, scaleMax) {
+        const width = 600;
+        const baseline = 167.5;
+        const chartHeight = 157.5;
+        const lastIndex = Math.max(1, values.length - 1);
+        return values.map((value, index) => {
+            const x = (index / lastIndex) * width;
+            const safeValue = Math.max(0, this.toNumber(value));
+            const y = baseline - Math.min(1, safeValue / scaleMax) * chartHeight;
+            return `${x.toFixed(2)},${y.toFixed(2)}`;
+        }).join(' ');
+    }
+
+    areaPath(points) {
+        if (!points) return '';
+        const firstX = points.split(' ', 1)[0].split(',')[0];
+        const lastPoint = points.slice(points.lastIndexOf(' ') + 1);
+        const lastX = lastPoint.split(',')[0];
+        return `M ${firstX} 167.5 L ${points.split(' ').join(' L ')} L ${lastX} 167.5 Z`;
+    }
+
+    niceScale(value) {
+        if (!Number.isFinite(value) || value <= 0) return 1000000;
+        const exponent = Math.pow(10, Math.floor(Math.log10(value)));
+        const fraction = value / exponent;
+        const ceiling = fraction <= 1 ? 1 : fraction <= 2 ? 2 : fraction <= 5 ? 5 : 10;
+        return Math.max(1000, ceiling * exponent);
     }
 
     updateSessions(clients) {
         if (!this.elements.sessionsBody) return;
-        this.elements.sessionsBody.innerHTML = clients.map(client => {
-            const transport = client.transport ? client.transport.toLowerCase() : 'udp';
-            let tagClass = transport.includes('tcp') ? 'tcp' : (transport.includes('interleaved') ? 'interleaved' : 'udp');
-            
-            const durationSeconds = parseInt(client.proxy);
-            const durationDisplay = isNaN(durationSeconds) ? '--' : this.formatDuration(durationSeconds);
-            const type = client.type === 'mitm' ? 'MITM' : 'HTTP';
-            
-            const upBps = (client.upstream_bandwidth || 0) / 1000000;
-            const downBps = (client.downstream_bandwidth || 0) / 1000000;
+        this.elements.sessionsBody.replaceChildren();
+        this.setText(this.elements.sessionCount, this.formatInteger(clients.length));
 
-            return `
-                <tr>
-                    <td style="color:var(--accent-blue)">${client.downstream}</td>
-                    <td>${client.upstream}</td>
-                    <td style="font-weight:700; font-size:0.7rem">${type}</td>
-                    <td style="color:#60a5fa; font-family:'JetBrains Mono'">${upBps.toFixed(2)} Mbps</td>
-                    <td style="color:#34d399; font-family:'JetBrains Mono'">${downBps.toFixed(2)} Mbps</td>
-                    <td><span class="tag ${tagClass}">${client.transport || 'UDP'}</span></td>
-                    <td>${durationDisplay}</td>
-                </tr>
-            `;
-        }).join('');
+        if (clients.length === 0) {
+            this.renderEmptySessions();
+            return;
+        }
+
+        const fragment = document.createDocumentFragment();
+        clients.forEach((client) => fragment.appendChild(this.createSessionRow(client || {})));
+        this.elements.sessionsBody.appendChild(fragment);
+    }
+
+    createSessionRow(client) {
+        const row = document.createElement('tr');
+        row.appendChild(this.createEndpointCell(client.downstream, 'Downstream'));
+        row.appendChild(this.createEndpointCell(client.upstream, 'Upstream'));
+
+        const typeCell = document.createElement('td');
+        const mode = document.createElement('span');
+        const isMitm = String(client.type || '').toLowerCase() === 'mitm';
+        mode.className = `mode-tag${isMitm ? ' mitm' : ''}`;
+        mode.textContent = isMitm ? 'RTSP MITM' : 'HTTP TUNNEL';
+        typeCell.appendChild(mode);
+        row.appendChild(typeCell);
+
+        const rateCell = document.createElement('td');
+        rateCell.className = 'rate-cell';
+        rateCell.appendChild(this.createRateLine(client.upstream_bandwidth, false));
+        rateCell.appendChild(this.createRateLine(client.downstream_bandwidth, true));
+        row.appendChild(rateCell);
+
+        const transportCell = document.createElement('td');
+        const transport = String(client.transport || 'UDP').toUpperCase();
+        const transportTag = document.createElement('span');
+        const tagClass = transport.includes('INTERLEAVED') ? 'interleaved' : transport.includes('TCP') ? 'tcp' : 'udp';
+        transportTag.className = `transport-tag ${tagClass}`;
+        transportTag.textContent = transport;
+        transportCell.appendChild(transportTag);
+        row.appendChild(transportCell);
+
+        const durationCell = document.createElement('td');
+        durationCell.textContent = this.formatDuration(client.proxy);
+        row.appendChild(durationCell);
+        return row;
+    }
+
+    createEndpointCell(value, label) {
+        const cell = document.createElement('td');
+        const wrapper = document.createElement('div');
+        const primary = document.createElement('span');
+        const secondary = document.createElement('span');
+        wrapper.className = 'endpoint-cell';
+        primary.className = 'endpoint-primary';
+        secondary.className = 'endpoint-secondary';
+        primary.textContent = String(value || 'Connecting...');
+        primary.title = primary.textContent;
+        secondary.textContent = label;
+        wrapper.append(primary, secondary);
+        cell.appendChild(wrapper);
+        return cell;
+    }
+
+    createRateLine(value, isDownstream) {
+        const line = document.createElement('span');
+        line.className = `rate-line${isDownstream ? ' down' : ''}`;
+        line.textContent = this.formatBitRate(this.toNumber(value));
+        return line;
+    }
+
+    renderEmptySessions() {
+        if (!this.elements.sessionsBody) return;
+        this.elements.sessionsBody.replaceChildren();
+
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        const state = document.createElement('div');
+        const icon = document.createElement('span');
+        const title = document.createElement('strong');
+        const description = document.createElement('span');
+
+        row.className = 'empty-row';
+        cell.colSpan = 6;
+        state.className = 'empty-state';
+        icon.className = 'empty-state-icon';
+        icon.textContent = '—';
+        title.textContent = '暂无活动会话';
+        description.textContent = '新的代理连接会自动显示在这里';
+        state.append(icon, title, description);
+        cell.appendChild(state);
+        row.appendChild(cell);
+        this.elements.sessionsBody.appendChild(row);
     }
 
     async fetchLogs() {
+        if (this.logsInFlight || this.logsPaused) return;
+        this.logsInFlight = true;
         try {
-            const urlParams = new URLSearchParams(window.location.search);
-            const token = urlParams.get('token');
-            const fetchUrl = token ? `${this.logEndpoint}?token=${token}` : this.logEndpoint;
-            const response = await fetch(fetchUrl);
-            if (!response.ok) return;
-            const data = await response.json();
-            this.updateLogs(data);
-        } catch (e) {}
+            const data = await this.fetchJson(this.logEndpoint);
+            this.mergeLogs(Array.isArray(data.logs) ? data.logs : []);
+        } catch (error) {
+            // Status polling owns the visible connection indicator.
+        } finally {
+            this.logsInFlight = false;
+        }
     }
 
-    updateLogs(data) {
+    mergeLogs(rawLogs) {
+        const incoming = rawLogs.map((line) => String(line));
+        if (this.serverLogs === null) {
+            this.serverLogs = incoming;
+            this.visibleLogs = incoming.slice(-500);
+            this.renderLogs(true);
+            return;
+        }
+
+        const overlap = this.findLogOverlap(this.serverLogs, incoming);
+        const additions = incoming.slice(overlap);
+        this.serverLogs = incoming;
+        if (additions.length === 0) return;
+
+        this.visibleLogs.push(...additions);
+        if (this.visibleLogs.length > 500) {
+            this.visibleLogs.splice(0, this.visibleLogs.length - 500);
+        }
+        this.renderLogs(true);
+    }
+
+    findLogOverlap(previous, next) {
+        const max = Math.min(previous.length, next.length);
+        for (let length = max; length > 0; length -= 1) {
+            let matches = true;
+            const previousStart = previous.length - length;
+            for (let index = 0; index < length; index += 1) {
+                if (previous[previousStart + index] !== next[index]) {
+                    matches = false;
+                    break;
+                }
+            }
+            if (matches) return length;
+        }
+        return 0;
+    }
+
+    renderLogs(newData = false) {
         if (!this.elements.logDisplay) return;
-        const logs = data.logs || [];
-        if (logs.length === 0) return;
-        
-        const lastEntry = logs[logs.length - 1];
-        if (lastEntry === this.lastLogTimestamp) return;
-        this.lastLogTimestamp = lastEntry;
-
-        const selectedLevel = parseInt(this.elements.logLevelSelect ? this.elements.logLevelSelect.value : "1");
-        
-        const filteredLogs = logs.filter(line => {
-            let lineLevel = 1; 
-            if (line.includes("[DEBUG]")) lineLevel = 0;
-            else if (line.includes("[INFO]")) lineLevel = 1;
-            else if (line.includes("[WARN]")) lineLevel = 2;
-            else if (line.includes("[ERROR]")) lineLevel = 3;
-            return lineLevel >= selectedLevel;
+        const selectedLevel = Number.parseInt(this.elements.logLevelSelect?.value || '1', 10);
+        const query = (this.elements.logSearch?.value || '').trim().toLocaleLowerCase();
+        const filtered = this.visibleLogs.filter((line) => {
+            return this.logLevel(line) >= selectedLevel && (!query || line.toLocaleLowerCase().includes(query));
         });
+        const wasAtBottom = this.isLogViewAtBottom();
+        this.elements.logDisplay.replaceChildren();
 
-        this.elements.logDisplay.innerHTML = filteredLogs.map(line => {
-            let cls = "info";
-            if (line.includes("[ERROR]")) cls = "error";
-            else if (line.includes("[WARN]")) cls = "warn";
-            else if (line.includes("[DEBUG]")) cls = "debug";
-            return `<div class="log-entry ${cls}">${line}</div>`;
-        }).join('');
-        this.elements.logDisplay.scrollTop = this.elements.logDisplay.scrollHeight;
+        if (filtered.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'log-empty';
+            empty.textContent = this.logsPaused ? '日志流已暂停' : query ? '没有匹配的日志' : '等待新的日志事件';
+            this.elements.logDisplay.appendChild(empty);
+            return;
+        }
+
+        const fragment = document.createDocumentFragment();
+        filtered.forEach((line) => {
+            const levelName = this.logLevelName(line);
+            const entry = document.createElement('div');
+            const mark = document.createElement('span');
+            const content = document.createElement('span');
+            entry.className = `log-entry ${levelName}`;
+            mark.className = 'log-level-mark';
+            content.className = 'log-text';
+            content.textContent = line;
+            entry.append(mark, content);
+            fragment.appendChild(entry);
+        });
+        this.elements.logDisplay.appendChild(fragment);
+
+        if (newData && wasAtBottom) {
+            this.elements.logDisplay.scrollTop = this.elements.logDisplay.scrollHeight;
+        }
     }
 
-    formatBytes(bytes) {
+    isLogViewAtBottom() {
+        const view = this.elements.logDisplay;
+        if (!view || view.scrollHeight <= view.clientHeight) return true;
+        return view.scrollHeight - view.scrollTop - view.clientHeight < 60;
+    }
+
+    logLevel(line) {
+        if (line.includes('[ERROR]')) return 3;
+        if (line.includes('[WARN]')) return 2;
+        if (line.includes('[DEBUG]')) return 0;
+        return 1;
+    }
+
+    logLevelName(line) {
+        const level = this.logLevel(line);
+        return level === 3 ? 'error' : level === 2 ? 'warn' : level === 0 ? 'debug' : 'info';
+    }
+
+    toggleLogs() {
+        this.logsPaused = !this.logsPaused;
+        if (this.elements.pauseLogsButton) {
+            this.elements.pauseLogsButton.textContent = this.logsPaused ? '继续' : '暂停';
+            this.elements.pauseLogsButton.classList.toggle('active', this.logsPaused);
+            this.elements.pauseLogsButton.setAttribute('aria-pressed', String(this.logsPaused));
+        }
+        this.renderLogs();
+        if (!this.logsPaused) this.fetchLogs();
+    }
+
+    setText(element, text) {
+        if (element) element.textContent = String(text);
+    }
+
+    toNumber(value) {
+        const number = Number(value);
+        return Number.isFinite(number) ? number : 0;
+    }
+
+    formatInteger(value) {
+        return Math.max(0, Math.trunc(this.toNumber(value))).toLocaleString('zh-CN');
+    }
+
+    formatBytes(value) {
+        const bytes = Math.max(0, this.toNumber(value));
         if (bytes === 0) return '0 B';
-        const k = 1024;
-        const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-        const i = Math.floor(Math.log(bytes) / Math.log(k));
-        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+        const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+        const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+        const amount = bytes / Math.pow(1024, index);
+        return `${this.compactNumber(amount)} ${units[index]}`;
     }
 
-    formatDuration(seconds) {
-        const h = Math.floor(seconds / 3600);
-        const m = Math.floor((seconds % 3600) / 60);
-        const s = seconds % 60;
-        return [h, m, s].map(v => v < 10 ? "0" + v : v).join(":");
+    formatBitRate(value) {
+        const bits = Math.max(0, this.toNumber(value));
+        const units = ['bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps'];
+        if (bits === 0) return '0 bps';
+        const index = Math.min(Math.floor(Math.log(bits) / Math.log(1000)), units.length - 1);
+        const amount = bits / Math.pow(1000, index);
+        return `${this.compactNumber(amount)} ${units[index]}`;
+    }
+
+    compactNumber(value) {
+        if (value >= 100) return value.toFixed(0);
+        if (value >= 10) return value.toFixed(1).replace(/\.0$/, '');
+        return value.toFixed(2).replace(/0+$/, '').replace(/\.$/, '');
+    }
+
+    formatDuration(rawSeconds) {
+        const seconds = Math.max(0, Math.trunc(this.toNumber(rawSeconds)));
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        const remaining = seconds % 60;
+        return [hours, minutes, remaining].map((part) => String(part).padStart(2, '0')).join(':');
     }
 }
 

--- a/webui/style.css
+++ b/webui/style.css
@@ -1,221 +1,1251 @@
 :root {
-    --bg-color: #0a0a0a;
-    --card-bg: #141414;
-    --text-primary: #ffffff;
-    --text-secondary: #a1a1aa;
-    --accent-blue: #60a5fa;
-    --accent-green: #34d399;
-    --accent-purple: #a78bfa;
-    --accent-orange: #fb923c;
-    --border-color: rgba(255, 255, 255, 0.08);
+    color-scheme: dark;
+    --bg: #07100f;
+    --bg-deep: #040a09;
+    --surface: rgba(15, 28, 26, 0.86);
+    --surface-solid: #0f1c1a;
+    --surface-raised: #142421;
+    --surface-hover: #172a27;
+    --border: rgba(172, 226, 209, 0.1);
+    --border-strong: rgba(172, 226, 209, 0.18);
+    --text: #f3f8f6;
+    --text-soft: #c7d5d1;
+    --muted: #7f9992;
+    --faint: #59716b;
+    --mint: #52e0b7;
+    --mint-bright: #75f3ce;
+    --mint-soft: rgba(82, 224, 183, 0.12);
+    --blue: #6d9dff;
+    --blue-soft: rgba(109, 157, 255, 0.12);
+    --violet: #a98bff;
+    --orange: #f4aa61;
+    --yellow: #f2cc67;
+    --red: #ff6f79;
+    --shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+    --radius-lg: 20px;
+    --radius-md: 14px;
+    --font-sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+    --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
 }
 
-* { box-sizing: border-box; margin: 0; padding: 0; }
+* {
+    box-sizing: border-box;
+}
+
+html {
+    min-width: 320px;
+    background: var(--bg-deep);
+}
 
 body {
-    font-family: 'Inter', -apple-system, sans-serif;
-    background-color: var(--bg-color);
-    color: var(--text-primary);
-    padding: 20px;
-    height: 100vh;
-    overflow: hidden;
+    min-height: 100vh;
+    margin: 0;
+    overflow-x: hidden;
+    background:
+        radial-gradient(circle at 76% -20%, rgba(65, 172, 145, 0.15), transparent 34rem),
+        linear-gradient(160deg, #081310 0%, #07100f 45%, #050c0b 100%);
+    color: var(--text);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
 }
 
-.container {
-    max-width: 1600px;
-    height: 100%;
+button,
+input,
+select {
+    font: inherit;
+}
+
+button,
+select {
+    cursor: pointer;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+a:focus-visible {
+    outline: 2px solid var(--mint);
+    outline-offset: 2px;
+}
+
+.ambient {
+    position: fixed;
+    z-index: 0;
+    border-radius: 999px;
+    pointer-events: none;
+    filter: blur(1px);
+    opacity: 0.45;
+}
+
+.ambient-top {
+    top: -22rem;
+    left: 18%;
+    width: 48rem;
+    height: 38rem;
+    border: 1px solid rgba(82, 224, 183, 0.09);
+    box-shadow: 0 0 120px rgba(82, 224, 183, 0.05) inset;
+}
+
+.ambient-side {
+    top: 30%;
+    right: -20rem;
+    width: 35rem;
+    height: 35rem;
+    background: rgba(47, 113, 97, 0.05);
+}
+
+.app-shell {
+    position: relative;
+    z-index: 1;
+    width: min(100% - 48px, 1680px);
     margin: 0 auto;
+}
+
+.topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 82px;
+    border-bottom: 1px solid var(--border);
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    color: inherit;
+    text-decoration: none;
+}
+
+.brand-mark {
+    display: grid;
+    width: 40px;
+    height: 40px;
+    place-items: center;
+    border: 1px solid rgba(82, 224, 183, 0.28);
+    border-radius: 12px;
+    background: linear-gradient(145deg, rgba(82, 224, 183, 0.16), rgba(82, 224, 183, 0.04));
+    box-shadow: 0 8px 24px rgba(32, 140, 110, 0.11), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.brand-mark svg {
+    width: 27px;
+    height: 27px;
+    fill: none;
+    stroke: var(--mint-bright);
+    stroke-linecap: round;
+    stroke-width: 1.8;
+}
+
+.brand-mark circle {
+    fill: var(--mint-bright);
+    stroke: none;
+}
+
+.brand > span:last-child {
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 2px;
 }
 
-header {
+.brand strong {
+    font-size: 16px;
+    letter-spacing: -0.02em;
+}
+
+.brand small {
+    color: var(--muted);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+}
+
+.topbar-actions {
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    gap: 10px;
 }
 
-h1 { font-size: 1.1rem; font-weight: 700; letter-spacing: -0.01em; }
-
-.status-badge {
-    padding: 4px 10px;
-    border-radius: 6px;
-    font-size: 0.7rem;
-    font-weight: 600;
-    background: rgba(52, 211, 153, 0.1);
-    color: var(--accent-green);
+.sync-info {
     display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+    margin-right: 5px;
+}
+
+.sync-info span {
+    color: var(--faint);
+    font-size: 10px;
+}
+
+.sync-info strong {
+    color: var(--text-soft);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 500;
+}
+
+.icon-button {
+    display: grid;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    place-items: center;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.025);
+    color: var(--muted);
+    transition: 160ms ease;
+}
+
+.icon-button:hover {
+    border-color: var(--border-strong);
+    background: var(--surface-raised);
+    color: var(--text);
+}
+
+.icon-button svg {
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.8;
+}
+
+.icon-button.loading svg {
+    animation: spin 700ms linear infinite;
+}
+
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 84px;
+    height: 36px;
+    justify-content: center;
+    border: 1px solid rgba(82, 224, 183, 0.18);
+    border-radius: 999px;
+    background: rgba(82, 224, 183, 0.08);
+    color: var(--mint-bright);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+}
+
+.status-pill.offline {
+    border-color: rgba(255, 111, 121, 0.2);
+    background: rgba(255, 111, 121, 0.08);
+    color: var(--red);
+}
+
+.status-pill.connecting {
+    border-color: rgba(242, 204, 103, 0.18);
+    background: rgba(242, 204, 103, 0.07);
+    color: var(--yellow);
+}
+
+.status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 0 4px rgba(82, 224, 183, 0.1);
+}
+
+.status-pill.online .status-dot {
+    animation: status-pulse 2s ease-out infinite;
+}
+
+.page-heading {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    padding: 38px 2px 26px;
+}
+
+.eyebrow,
+.panel-kicker {
+    margin: 0;
+    color: var(--mint);
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+}
+
+.page-heading h1 {
+    margin: 7px 0 7px;
+    font-size: clamp(25px, 2.3vw, 34px);
+    font-weight: 650;
+    letter-spacing: -0.045em;
+}
+
+.heading-copy {
+    margin: 0;
+    color: var(--muted);
+    font-size: 13px;
+}
+
+.live-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding-bottom: 5px;
+    color: var(--faint);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+}
+
+.live-label span,
+.mini-pulse {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--mint);
+    box-shadow: 0 0 0 4px rgba(82, 224, 183, 0.08);
+}
+
+.metric-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.metric-card,
+.panel {
+    position: relative;
+    border: 1px solid var(--border);
+    background: linear-gradient(145deg, rgba(18, 33, 30, 0.94), rgba(12, 24, 22, 0.9));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.018), var(--shadow);
+    backdrop-filter: blur(18px);
+}
+
+.metric-card {
+    display: flex;
+    min-height: 126px;
+    align-items: flex-start;
+    gap: 14px;
+    overflow: hidden;
+    padding: 22px;
+    border-radius: var(--radius-md);
+}
+
+.metric-card::after {
+    position: absolute;
+    right: -28px;
+    bottom: -52px;
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    background: var(--card-glow, rgba(82, 224, 183, 0.05));
+    content: "";
+    filter: blur(12px);
+    pointer-events: none;
+}
+
+.metric-up { --card-glow: rgba(82, 224, 183, 0.09); }
+.metric-down { --card-glow: rgba(109, 157, 255, 0.09); }
+.metric-clients { --card-glow: rgba(169, 139, 255, 0.08); }
+.metric-buffer { --card-glow: rgba(244, 170, 97, 0.08); }
+
+.metric-icon {
+    display: grid;
+    flex: 0 0 auto;
+    width: 38px;
+    height: 38px;
+    place-items: center;
+    border: 1px solid rgba(82, 224, 183, 0.15);
+    border-radius: 11px;
+    background: var(--mint-soft);
+    color: var(--mint-bright);
+}
+
+.metric-down .metric-icon {
+    border-color: rgba(109, 157, 255, 0.15);
+    background: var(--blue-soft);
+    color: var(--blue);
+}
+
+.metric-clients .metric-icon {
+    border-color: rgba(169, 139, 255, 0.15);
+    background: rgba(169, 139, 255, 0.1);
+    color: var(--violet);
+}
+
+.metric-buffer .metric-icon {
+    border-color: rgba(244, 170, 97, 0.15);
+    background: rgba(244, 170, 97, 0.09);
+    color: var(--orange);
+}
+
+.metric-icon svg {
+    width: 20px;
+    height: 20px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.7;
+}
+
+.metric-content {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+}
+
+.metric-label {
+    margin: 1px 0 7px;
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.metric-value {
+    overflow: hidden;
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: clamp(20px, 2vw, 27px);
+    font-weight: 600;
+    letter-spacing: -0.045em;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.metric-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    margin-top: 9px;
+    color: var(--faint);
+    font-size: 10px;
+}
+
+.metric-meta b {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-weight: 500;
+}
+
+.mini-pulse {
+    width: 5px;
+    height: 5px;
+    box-shadow: none;
+}
+
+.metric-buffer-content {
+    padding-bottom: 8px;
+}
+
+.metric-progress {
+    position: absolute;
+    right: 22px;
+    bottom: 17px;
+    left: 74px;
+    height: 3px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.055);
+}
+
+.metric-progress span {
+    display: block;
+    width: 0;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--orange), #f3cc72);
+    transition: width 500ms ease;
+}
+
+.insight-grid,
+.workspace-grid {
+    display: grid;
+    gap: 14px;
+    margin-top: 14px;
+}
+
+.insight-grid {
+    grid-template-columns: minmax(0, 2.05fr) minmax(300px, 0.95fr);
+}
+
+.workspace-grid {
+    grid-template-columns: minmax(0, 1.25fr) minmax(360px, 0.75fr);
+}
+
+.panel {
+    min-width: 0;
+    overflow: hidden;
+    border-radius: var(--radius-lg);
+}
+
+.panel-header {
+    display: flex;
+    min-height: 71px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 17px 20px;
+    border-bottom: 1px solid var(--border);
+}
+
+.panel-header h2 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 5px 0 0;
+    font-size: 14px;
+    font-weight: 650;
+    letter-spacing: -0.015em;
+}
+
+.chart-legend {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    color: var(--muted);
+    font-size: 10px;
+}
+
+.chart-legend span {
+    display: inline-flex;
     align-items: center;
     gap: 6px;
-    border: 1px solid rgba(52, 211, 153, 0.2);
 }
-.dot { width: 5px; height: 5px; border-radius: 50%; background: var(--accent-green); }
 
-/* Horizontal Status Bar */
-.status-bar {
+.chart-legend i {
+    width: 14px;
+    height: 2px;
+    border-radius: 99px;
+}
+
+.legend-up { background: var(--mint); }
+.legend-down { background: var(--blue); }
+
+.chart-summary {
     display: flex;
-    gap: 0;
-    background: var(--card-bg);
-    padding: 12px 16px;
-    border-radius: 10px;
-    border: 1px solid var(--border-color);
+    gap: 30px;
+    padding: 18px 22px 2px;
 }
 
-.stat-item {
-    flex: 1;
+.chart-summary > div {
     display: flex;
     flex-direction: column;
     gap: 4px;
-    padding-left: 12px;
-    border-left: 1px solid var(--border-color);
-}
-.stat-item:first-child { border-left: none; padding-left: 0; }
-
-.stat-item .label { font-size: 0.65rem; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; }
-.stat-item .value { font-size: 1.2rem; font-weight: 600; }
-
-/* Main Content: 2 Columns */
-.main-content {
-    flex-grow: 1;
-    display: grid;
-    grid-template-columns: 6.5fr 3.5fr;
-    gap: 16px;
-    overflow: hidden;
 }
 
-section {
-    background: var(--card-bg);
-    border-radius: 12px;
-    border: 1px solid var(--border-color);
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
+.chart-summary span {
+    color: var(--faint);
+    font-size: 9px;
 }
 
-.card-header {
-    padding: 16px 20px;
-    border-bottom: 1px solid var(--border-color);
+.chart-summary strong {
+    color: var(--text-soft);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.chart-summary > div:first-child strong { color: var(--mint); }
+.chart-summary > div:nth-child(2) strong { color: var(--blue); }
+.chart-summary .chart-scale { margin-left: auto; text-align: right; }
+
+.chart-wrap {
+    height: 198px;
+    padding: 8px 20px 18px;
+}
+
+.traffic-chart {
+    display: block;
+    width: 100%;
+    height: calc(100% - 18px);
+    overflow: visible;
+}
+
+.chart-grid line {
+    stroke: rgba(181, 221, 209, 0.075);
+    stroke-dasharray: 3 5;
+    stroke-width: 1;
+    vector-effect: non-scaling-stroke;
+}
+
+.chart-area {
+    stroke: none;
+    transition: d 300ms ease;
+}
+
+.up-area { fill: url(#up-area-gradient); }
+.down-area { fill: url(#down-area-gradient); }
+
+.chart-line {
+    fill: none;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
+    vector-effect: non-scaling-stroke;
+}
+
+.up-line { stroke: var(--mint); }
+.down-line { stroke: var(--blue); }
+
+.chart-axis {
     display: flex;
     justify-content: space-between;
+    padding-top: 5px;
+    color: var(--faint);
+    font-family: var(--font-mono);
+    font-size: 8px;
+}
+
+.pool-panel {
+    display: flex;
+    flex-direction: column;
+}
+
+.health-chip {
+    padding: 5px 9px;
+    border: 1px solid rgba(82, 224, 183, 0.15);
+    border-radius: 999px;
+    background: var(--mint-soft);
+    color: var(--mint-bright);
+    font-size: 9px;
+    font-weight: 700;
+}
+
+.health-chip.warning {
+    border-color: rgba(242, 204, 103, 0.2);
+    background: rgba(242, 204, 103, 0.08);
+    color: var(--yellow);
+}
+
+.health-chip.critical {
+    border-color: rgba(255, 111, 121, 0.2);
+    background: rgba(255, 111, 121, 0.08);
+    color: var(--red);
+}
+
+.pool-content {
+    display: grid;
+    flex: 1;
+    grid-template-columns: 142px 1fr;
+    align-items: center;
+    gap: 20px;
+    padding: 22px;
+}
+
+.buffer-gauge {
+    --gauge-value: 0deg;
+    position: relative;
+    display: grid;
+    width: 132px;
+    height: 132px;
+    place-items: center;
+    border-radius: 50%;
+    background: conic-gradient(var(--mint) var(--gauge-value), rgba(255, 255, 255, 0.055) 0);
+    box-shadow: 0 0 38px rgba(82, 224, 183, 0.055);
+    transition: background 500ms ease;
+}
+
+.buffer-gauge::before {
+    position: absolute;
+    width: 108px;
+    height: 108px;
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    background: var(--surface-solid);
+    content: "";
+}
+
+.buffer-gauge > div {
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3px;
+}
+
+.buffer-gauge strong {
+    font-family: var(--font-mono);
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: -0.04em;
+}
+
+.buffer-gauge span {
+    color: var(--faint);
+    font-size: 9px;
+}
+
+.pool-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px 15px;
+    margin: 0;
+}
+
+.pool-stats div {
+    min-width: 0;
+}
+
+.pool-stats dt {
+    margin-bottom: 6px;
+    color: var(--faint);
+    font-size: 9px;
+}
+
+.pool-stats dd {
+    overflow: hidden;
+    margin: 0;
+    color: var(--text-soft);
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 500;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.count-badge {
+    display: inline-grid;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 6px;
+    place-items: center;
+    border-radius: 6px;
+    background: var(--mint-soft);
+    color: var(--mint-bright);
+    font-family: var(--font-mono);
+    font-size: 10px;
+}
+
+.panel-note {
+    color: var(--faint);
+    font-size: 9px;
+}
+
+.table-container {
+    min-height: 286px;
+    max-height: 440px;
+    overflow: auto;
+}
+
+table {
+    width: 100%;
+    min-width: 790px;
+    border-collapse: collapse;
+}
+
+th {
+    position: sticky;
+    z-index: 2;
+    top: 0;
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--border);
+    background: rgba(13, 26, 23, 0.98);
+    color: var(--faint);
+    font-size: 9px;
+    font-weight: 650;
+    letter-spacing: 0.025em;
+    text-align: left;
+}
+
+td {
+    padding: 15px 18px;
+    border-bottom: 1px solid rgba(172, 226, 209, 0.055);
+    color: var(--text-soft);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    vertical-align: middle;
+}
+
+tbody tr {
+    transition: background 150ms ease;
+}
+
+tbody tr:hover {
+    background: rgba(82, 224, 183, 0.027);
+}
+
+.endpoint-cell {
+    display: flex;
+    max-width: 190px;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.endpoint-primary {
+    overflow: hidden;
+    color: var(--text);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.endpoint-secondary {
+    color: var(--faint);
+    font-family: var(--font-sans);
+    font-size: 8px;
+}
+
+.mode-tag,
+.transport-tag {
+    display: inline-flex;
+    align-items: center;
+    min-height: 22px;
+    padding: 0 8px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.025);
+    color: var(--muted);
+    font-family: var(--font-sans);
+    font-size: 8px;
+    font-weight: 700;
+}
+
+.mode-tag.mitm {
+    border-color: rgba(169, 139, 255, 0.17);
+    background: rgba(169, 139, 255, 0.08);
+    color: #c2b0ff;
+}
+
+.transport-tag.tcp,
+.transport-tag.interleaved {
+    border-color: rgba(244, 170, 97, 0.17);
+    background: rgba(244, 170, 97, 0.08);
+    color: var(--orange);
+}
+
+.transport-tag.udp {
+    border-color: rgba(109, 157, 255, 0.17);
+    background: rgba(109, 157, 255, 0.08);
+    color: #8cb3ff;
+}
+
+.rate-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.rate-line {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    white-space: nowrap;
+}
+
+.rate-line::before {
+    color: var(--mint);
+    content: "↑";
+}
+
+.rate-line.down::before {
+    color: var(--blue);
+    content: "↓";
+}
+
+.empty-row:hover {
+    background: transparent;
+}
+
+.empty-row td {
+    height: 240px;
+    border: 0;
+    text-align: center;
+}
+
+.empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    color: var(--faint);
+    font-family: var(--font-sans);
+}
+
+.empty-state-icon {
+    display: grid;
+    width: 44px;
+    height: 44px;
+    margin-bottom: 12px;
+    place-items: center;
+    border: 1px solid var(--border);
+    border-radius: 13px;
+    background: rgba(255, 255, 255, 0.02);
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 16px;
+}
+
+.empty-state strong {
+    margin-bottom: 5px;
+    color: var(--text-soft);
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.empty-state span {
+    font-size: 9px;
+}
+
+.logs-header {
     align-items: center;
 }
-.card-header h2 { font-size: 0.8rem; font-weight: 700; color: var(--text-secondary); text-transform: uppercase; }
 
-/* Tables */
-.table-container { flex-grow: 1; overflow-y: auto; padding: 0 10px; }
-table { width: 100%; border-collapse: collapse; }
-th { text-align: left; padding: 12px 10px; font-size: 0.7rem; color: var(--text-secondary); position: sticky; top: 0; background: var(--card-bg); z-index: 1; }
-td { padding: 12px 10px; font-size: 0.8rem; border-bottom: 1px solid rgba(255,255,255,0.02); font-family: 'JetBrains Mono', monospace; }
+.log-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
 
-/* Logs */
+.log-search {
+    display: flex;
+    width: 126px;
+    height: 30px;
+    align-items: center;
+    gap: 6px;
+    padding: 0 9px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.12);
+    color: var(--faint);
+    transition: border-color 150ms ease;
+}
+
+.log-search:focus-within {
+    border-color: rgba(82, 224, 183, 0.35);
+}
+
+.log-search svg {
+    width: 13px;
+    height: 13px;
+    flex: 0 0 auto;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-width: 1.8;
+}
+
+.log-search input {
+    width: 100%;
+    min-width: 0;
+    padding: 0;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: var(--text-soft);
+    font-size: 9px;
+}
+
+.log-search input::placeholder {
+    color: var(--faint);
+}
+
+.log-actions select,
+.text-button {
+    height: 30px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.12);
+    color: var(--muted);
+    font-size: 9px;
+}
+
+.log-actions select {
+    padding: 0 24px 0 9px;
+}
+
+.text-button {
+    padding: 0 10px;
+    transition: 150ms ease;
+}
+
+.text-button:hover,
+.text-button.active {
+    border-color: var(--border-strong);
+    background: var(--surface-hover);
+    color: var(--text);
+}
+
+.text-button.danger:hover {
+    border-color: rgba(255, 111, 121, 0.2);
+    background: rgba(255, 111, 121, 0.08);
+    color: var(--red);
+}
+
 .log-container {
-    flex-grow: 1;
-    overflow-y: auto;
-    overflow-x: hidden;
-    padding: 16px;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.75rem;
+    min-height: 286px;
+    max-height: 440px;
+    overflow: auto;
+    padding: 10px 0 14px;
+    background:
+        linear-gradient(rgba(7, 14, 13, 0.55), rgba(7, 14, 13, 0.55)),
+        repeating-linear-gradient(0deg, transparent, transparent 25px, rgba(255, 255, 255, 0.012) 26px);
+    font-family: var(--font-mono);
+    scrollbar-gutter: stable;
 }
-.log-entry { 
-    margin-bottom: 6px; 
-    line-height: 1.5; 
-    border-left: 2px solid transparent; 
-    padding-left: 10px; 
+
+.log-entry {
+    display: grid;
+    grid-template-columns: 5px minmax(0, 1fr);
+    gap: 10px;
+    margin: 0;
+    padding: 5px 15px;
+    color: #8ba29c;
+    font-size: 9px;
+    line-height: 1.65;
+}
+
+.log-entry:hover {
+    background: rgba(255, 255, 255, 0.018);
+}
+
+.log-level-mark {
+    width: 4px;
+    height: 4px;
+    margin-top: 6px;
+    border-radius: 50%;
+    background: var(--blue);
+    box-shadow: 0 0 7px rgba(109, 157, 255, 0.35);
+}
+
+.log-text {
+    min-width: 0;
     white-space: pre-wrap;
-    word-break: break-word;
-}
-.log-entry.error { 
-    border-left-color: #ef4444; 
-    color: #f87171; 
-    background: rgba(239, 68, 68, 0.05); 
-}
-.log-entry.warn { 
-    border-left-color: #f59e0b; 
-    color: #fbbf24; 
-    background: rgba(245, 158, 11, 0.05); 
-}
-.log-entry.info { 
-    border-left-color: var(--accent-blue); 
-    color: #7dd3fc; 
-}
-.log-entry.debug { 
-    border-left-color: var(--accent-purple); 
-    color: #c084fc; 
-    opacity: 0.8;
+    overflow-wrap: anywhere;
 }
 
-/* Tags */
-.tag { padding: 2px 8px; border-radius: 4px; font-size: 0.65rem; font-weight: 600; }
-.tag.udp { background: rgba(96, 165, 250, 0.1); color: var(--accent-blue); }
-.tag.tcp { background: rgba(251, 146, 60, 0.1); color: var(--accent-orange); }
-.tag.interleaved { background: rgba(167, 139, 250, 0.1); color: var(--accent-purple); }
-
-/* Controls */
-.controls { display: flex; gap: 8px; }
-.controls select {
-    background: #000; border: 1px solid var(--border-color); color: var(--text-secondary);
-    padding: 4px 8px; border-radius: 4px; font-size: 0.65rem; cursor: pointer;
+.log-entry.debug {
+    color: #887da0;
 }
-.controls button {
-    background: transparent; border: 1px solid var(--border-color); color: var(--text-secondary);
-    padding: 4px 10px; border-radius: 4px; font-size: 0.65rem; cursor: pointer; text-transform: uppercase;
+
+.log-entry.debug .log-level-mark {
+    background: var(--violet);
+    box-shadow: 0 0 7px rgba(169, 139, 255, 0.35);
 }
-.controls button:hover { background: rgba(239, 68, 68, 0.1); color: #ef4444; }
 
-/* Scrollbar */
-::-webkit-scrollbar { width: 4px; }
-::-webkit-scrollbar-thumb { background: #333; border-radius: 10px; }
+.log-entry.warn {
+    color: #c2a767;
+}
 
-/* --- Responsive Adjustments --- */
+.log-entry.warn .log-level-mark {
+    background: var(--yellow);
+    box-shadow: 0 0 7px rgba(242, 204, 103, 0.35);
+}
 
-@media (max-width: 1024px) {
-    body {
-        height: auto;
-        overflow-y: auto;
-        padding: 12px;
+.log-entry.error {
+    color: #d8848b;
+}
+
+.log-entry.error .log-level-mark {
+    background: var(--red);
+    box-shadow: 0 0 7px rgba(255, 111, 121, 0.35);
+}
+
+.log-empty {
+    display: grid;
+    min-height: 260px;
+    place-items: center;
+    color: var(--faint);
+    font-family: var(--font-sans);
+    font-size: 10px;
+}
+
+footer {
+    display: flex;
+    height: 65px;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 9px;
+    color: #435a54;
+    font-family: var(--font-mono);
+    font-size: 8px;
+    letter-spacing: 0.04em;
+}
+
+.footer-divider {
+    width: 3px;
+    height: 3px;
+    border-radius: 50%;
+    background: #435a54;
+}
+
+::-webkit-scrollbar {
+    width: 7px;
+    height: 7px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    border: 2px solid transparent;
+    border-radius: 99px;
+    background: rgba(149, 184, 174, 0.2);
+    background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: rgba(149, 184, 174, 0.32);
+    background-clip: padding-box;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+@keyframes status-pulse {
+    0% { box-shadow: 0 0 0 0 rgba(82, 224, 183, 0.3); }
+    65%, 100% { box-shadow: 0 0 0 6px rgba(82, 224, 183, 0); }
+}
+
+@media (max-width: 1200px) {
+    .metric-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    .container {
-        height: auto;
+    .workspace-grid {
+        grid-template-columns: 1fr;
     }
 
-    .status-bar {
-        flex-wrap: wrap;
-        gap: 12px;
-    }
-
-    .stat-item {
-        flex: 1 1 calc(50% - 12px); /* 2 items per row on tablets */
-        border-left: none;
-        background: rgba(255, 255, 255, 0.02);
-        padding: 12px;
-        border-radius: 8px;
-    }
-
-    .main-content {
-        grid-template-columns: 1fr; /* Stack columns */
-        height: auto;
-    }
-
-    section {
-        height: 500px; /* Fixed height for scrollable areas in stack mode */
+    .logs-panel .log-container {
+        max-height: 360px;
     }
 }
 
-@media (max-width: 640px) {
-    .stat-item {
-        flex: 1 1 100%; /* 1 item per row on mobile */
+@media (max-width: 900px) {
+    .app-shell {
+        width: min(100% - 28px, 1680px);
     }
-    
-    header {
-        flex-direction: column;
+
+    .insight-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .pool-content {
+        min-height: 230px;
+        grid-template-columns: 160px 1fr;
+        justify-content: center;
+    }
+
+    .logs-header {
         align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .log-actions {
+        width: 100%;
+        flex-wrap: wrap;
+    }
+
+    .log-search {
+        flex: 1 1 160px;
+    }
+}
+
+@media (max-width: 620px) {
+    .app-shell {
+        width: min(100% - 20px, 1680px);
+    }
+
+    .topbar {
+        min-height: 72px;
+    }
+
+    .sync-info {
+        display: none;
+    }
+
+    .brand-mark {
+        width: 36px;
+        height: 36px;
+    }
+
+    .page-heading {
+        align-items: flex-start;
+        padding: 28px 2px 20px;
+    }
+
+    .heading-copy {
+        max-width: 260px;
+        line-height: 1.6;
+    }
+
+    .live-label {
+        display: none;
+    }
+
+    .metric-grid {
+        grid-template-columns: 1fr;
         gap: 10px;
     }
-    
-    .status-badge {
+
+    .metric-card {
+        min-height: 110px;
+        padding: 18px;
+    }
+
+    .metric-progress {
+        right: 18px;
+        bottom: 14px;
+        left: 70px;
+    }
+
+    .chart-summary {
+        gap: 16px;
+        padding-inline: 18px;
+    }
+
+    .chart-summary .chart-scale {
+        display: none;
+    }
+
+    .chart-wrap {
+        padding-inline: 16px;
+    }
+
+    .pool-content {
+        grid-template-columns: 1fr;
+        justify-items: center;
+    }
+
+    .pool-stats {
         width: 100%;
+    }
+
+    .panel-header {
+        padding: 16px;
+    }
+
+    .panel-note {
+        display: none;
+    }
+
+    .table-container,
+    .log-container {
+        min-height: 340px;
+    }
+
+    .log-actions select {
+        flex: 1;
+    }
+
+    footer {
         justify-content: center;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
     }
 }


### PR DESCRIPTION
## What changed

- Harden RTSP/HTTP request and response parsing with bounded buffering and stricter validation.
- Fix socket, timer, RTP source, redirect, keepalive, and session teardown edge cases.
- Validate ports, CIDR ranges, Content-Length values, configuration boundaries, and resolved redirect targets.
- Replace the admin WebUI with a responsive dark monitoring dashboard, bandwidth trends, buffer-pool health, session visibility, and improved log controls.
- Remove external frontend dependencies and avoid rendering API data through unsafe HTML injection paths.

## Why

Malformed protocol input and exceptional configuration values could previously cause crashes, resource leaks, incomplete nonblocking responses, or unsafe path and redirect behavior. The existing WebUI also provided limited operational visibility and depended on external font assets.

## Impact

The proxy is more resilient to malformed traffic and abnormal upstream behavior, while operators get a clearer real-time view of bandwidth, sessions, buffers, and logs. Existing API routes and authentication behavior remain compatible.

## Validation

- Meson/Ninja release build completed successfully.
- Direct release and ASan/UBSan builds completed successfully.
- Runtime HTTP, RTSP, split-request, traversal, large-response, invalid Content-Length, and sanitizer smoke tests passed.
- All 12 installer logic tests passed.
- GitHub Build Check passed for commit `0d5d3e8`: https://github.com/plsy1/rtsproxy/actions/runs/29384581103