### PR TITLE
Harden RTSP proxy reliability, security, and playback handling

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,18 +7,56 @@ on:
       - 'src/**'
       - 'include/**'
       - 'openwrt/**'
+      - 'test/**'
+      - 'meson.build'
+      - 'meson_options.txt'
+      - 'install.sh'
+      - '.github/workflows/check.yml'
   pull_request:
     branches: [ "**" ]
     paths:
       - 'src/**'
       - 'include/**'
       - 'openwrt/**'
+      - 'test/**'
+      - 'meson.build'
+      - 'meson_options.txt'
+      - 'install.sh'
+      - '.github/workflows/check.yml'
   workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson ninja-build g++
+
+      - name: Setup
+        run: meson setup builddir -Dtests=true
+
+      - name: Build
+        run: meson compile -C builddir
+
+      - name: Run tests
+        run: meson test -C builddir --print-errorlogs
+
+      - name: Upload test log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: meson-testlog
+          path: builddir/meson-logs/testlog.txt
+
   native-build:
     name: Native Build Check
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,7 @@ bin
 openwrt-sdk-x86_64
 toolchains
 build-static-x64
+build
+builddir
 logs
 example

--- a/config.json
+++ b/config.json
@@ -42,7 +42,7 @@
         {
             "action": "timeshift",
             "match": "tvdr={number}GMT-{number}GMT",
-            "shift_hours": -8,
+            "shift_hours": -6,
             "description": "将时间区间前移8小时"
         }
     ],

--- a/dockerfile
+++ b/dockerfile
@@ -4,6 +4,12 @@ WORKDIR /app
 
 COPY rtsproxy /app/rtsproxy
 
+# Without config.json the built-in blacklist is empty and every upstream is
+# allowed; without webui/ the /admin/ dashboard 404s. Both are looked up
+# relative to WORKDIR at runtime.
+COPY config.json /app/config.json
+COPY webui /app/webui
+
 RUN chmod +x /app/rtsproxy
 
 EXPOSE 8554

--- a/include/core/logger.h
+++ b/include/core/logger.h
@@ -26,10 +26,24 @@ public:
     static void debug(const std::string &msg);
     static void flush();
 
+    /**
+     * Async-signal-safe emergency logging: raw write(2) to the log file and to
+     * stderr, no lock, no allocation, no iostreams.
+     *
+     * log()/flush() must never be used from a signal handler. They take
+     * logMutex, so a SIGSEGV raised while the logger already holds it would
+     * deadlock the handler; the worker would then hang instead of dying, and
+     * the watchdog's blocking waitpid() would never return to restart it.
+     */
+    static void emergency(const char *msg);
+
     static void setLogFile(const std::string &path, size_t maxLines = 10000);
     static std::vector<std::string> getRecentLogs();
 
 private:
+    // Raw descriptor onto the same log file, kept open purely for emergency().
+    static int emergencyFd;
+
     static std::mutex logMutex;
     static std::ofstream logFile;
     static std::string logFilePath;

--- a/include/core/port_pool.h
+++ b/include/core/port_pool.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <stdint.h>
+#include <chrono>
+#include <map>
 #include <mutex>
 #include <set>
 
@@ -28,8 +30,8 @@ public:
 
     /**
      * Mark a port as externally occupied (failed to bind).
-     * This port is skipped for the remaining lifetime of the process:
-     * there is no expiry and no way to un-mark it.
+     * The port is skipped until the mark expires, so a process that transiently
+     * holds a port cannot permanently shrink the range.
      */
     void mark_occupied(uint16_t port);
 
@@ -40,12 +42,23 @@ private:
     PortPool(const PortPool&) = delete;
     PortPool& operator=(const PortPool&) = delete;
 
+    // Caller must hold mutex_.
+    void purge_expired_marks();
+
+    // Long enough to stop retrying a port that something else really is
+    // sitting on, short enough that the range recovers on its own.
+    static constexpr std::chrono::seconds kOccupiedTtl{300};
+
     std::mutex mutex_;
     uint16_t start_port_{20000};
     uint16_t end_port_{40000};
     uint16_t next_port_{20000};
-    
+
     std::set<uint16_t> used_ports_;
     // Even ports handed out by acquire_pair() and not yet released.
     std::set<uint16_t> allocated_bases_;
+    // Ports blocked because some other process holds them, and when the block
+    // was placed. Distinct from allocated_bases_ so that expiry can never free
+    // a port that this pool has genuinely handed out.
+    std::map<uint16_t, std::chrono::steady_clock::time_point> occupied_marks_;
 };

--- a/include/core/port_pool.h
+++ b/include/core/port_pool.h
@@ -21,12 +21,15 @@ public:
 
     /**
      * Release a pair of ports starting with 'port'.
+     * 'port' must be the even port returned by a previous acquire_pair();
+     * anything else (odd port, foreign port, double release) is ignored.
      */
     void release_pair(uint16_t port);
 
     /**
      * Mark a port as externally occupied (failed to bind).
-     * This port will be skipped for a while.
+     * This port is skipped for the remaining lifetime of the process:
+     * there is no expiry and no way to un-mark it.
      */
     void mark_occupied(uint16_t port);
 
@@ -43,4 +46,6 @@ private:
     uint16_t next_port_{20000};
     
     std::set<uint16_t> used_ports_;
+    // Even ports handed out by acquire_pair() and not yet released.
+    std::set<uint16_t> allocated_bases_;
 };

--- a/include/protocol/rtp_pipeline.h
+++ b/include/protocol/rtp_pipeline.h
@@ -18,9 +18,14 @@ public:
     // Reset the pipeline state (e.g. for a new stream/play)
     void reset();
 
+    // Number of packets dropped while waiting for a keyframe before the gate is
+    // forced open, so an undetectable stream still plays instead of staying black.
+    static constexpr uint32_t KEYFRAME_WAIT_LIMIT = 1024;
+
 private:
     void strip_rtp_padding_and_ts_null(uint8_t *buf, size_t &len);
     bool check_keyframe(const uint8_t *buf, size_t len);
 
     bool wait_for_keyframe_;
+    uint32_t dropped_while_waiting_;
 };

--- a/include/protocol/rtsp_parser.h
+++ b/include/protocol/rtsp_parser.h
@@ -33,6 +33,7 @@ public:
     static int parse_url(const std::string &url, rtspCtx &ctx);
     static int get_content_length(const std::string &resp);
     static std::string extract_header_value(const std::string &msg, const std::string &header_name);
+    static std::string replace_request_uri(const std::string &request, const std::string &uri);
 
 private:
 };

--- a/include/utils/stun_client.h
+++ b/include/utils/stun_client.h
@@ -7,7 +7,11 @@ class StunClient
 {
 public:
     static int send_stun_mapping_request(int s);
-    static int extract_stun_mapping_from_response(unsigned char *rsp, size_t rsp_len, std::string &out_pub_ip, uint16_t &out_pub_port);
+
+    // `s` is the socket the request went out on. The response is only accepted
+    // if it carries the transaction ID that was sent on that same socket, so
+    // the caller must pass the fd rather than just the received bytes.
+    static int extract_stun_mapping_from_response(int s, unsigned char *rsp, size_t rsp_len, std::string &out_pub_ip, uint16_t &out_pub_port);
 private:
     static void gen_tid(unsigned char tid[12]);
     static void put16(unsigned char *p, uint16_t v);

--- a/include/utils/url_rewriter.h
+++ b/include/utils/url_rewriter.h
@@ -23,5 +23,6 @@ private:
     static std::vector<std::string> split(const std::string &str, char delimiter);
     static std::string join(const std::vector<std::string> &parts, const std::string &delimiter);
     static std::string simplifyToRegex(const std::string &match_pattern);
+    static std::string expandReplacement(const std::string &replacement);
     static std::string shiftTime(const std::string &time_str, int shift_hours);
 };

--- a/meson.build
+++ b/meson.build
@@ -81,6 +81,7 @@ if get_option('tests')
         'rtp_pipeline',
         'port_pool',
         'server_config',
+        'stun_client',
     ]
 
     foreach name : test_names

--- a/meson.build
+++ b/meson.build
@@ -21,38 +21,84 @@ atomic_dep = cpp.find_library('atomic', required: false)
 src_dir = 'src'
 inc_dir = 'include'
 
+inc = include_directories(inc_dir)
+
+# Modules with no epoll/socket dependency. They form a self-contained link set,
+# which is what makes them unit-testable on their own.
+testable_srcs = files(
+    src_dir / 'core/logger.cpp',
+    src_dir / 'core/port_pool.cpp',
+    src_dir / 'core/server_config.cpp',
+    src_dir / 'protocol/request_parser.cpp',
+    src_dir / 'protocol/rtsp_parser.cpp',
+    src_dir / 'protocol/rtp_pipeline.cpp',
+    src_dir / 'utils/blacklist_checker.cpp',
+    src_dir / 'utils/dns_resolver.cpp',
+    src_dir / 'utils/url_rewriter.cpp',
+    src_dir / 'utils/stun_client.cpp',
+)
+
+# Everything that drives the event loop and the sockets.
+app_srcs = files(
+    src_dir / 'main.cpp',
+    src_dir / 'core/epoll_loop.cpp',
+    src_dir / 'core/proxy_server.cpp',
+    src_dir / 'handlers/master_handle.cpp',
+    src_dir / 'handlers/api_handle.cpp',
+    src_dir / 'handlers/rtsp_to_http_handle.cpp',
+    src_dir / 'handlers/rtsp_to_rtsp_handle.cpp',
+    src_dir / 'clients/rtsp_to_http_client.cpp',
+    src_dir / 'clients/rtsp_to_rtsp_client.cpp',
+    src_dir / 'utils/socket_helper.cpp',
+)
+
+testable_lib = static_library(
+    'rtsproxy_testable',
+    testable_srcs,
+    include_directories: inc,
+    install: false,
+)
+
 executable(
     'rtsproxy',
-    files(
-        src_dir / 'main.cpp',
-        # Core
-        src_dir / 'core/epoll_loop.cpp',
-        src_dir / 'core/logger.cpp',
-        src_dir / 'core/server_config.cpp',
-        src_dir / 'core/proxy_server.cpp',
-        src_dir / 'core/port_pool.cpp',
-        # Handlers
-        src_dir / 'handlers/master_handle.cpp',
-        src_dir / 'handlers/api_handle.cpp',
-        src_dir / 'handlers/rtsp_to_http_handle.cpp',
-        src_dir / 'handlers/rtsp_to_rtsp_handle.cpp',
-        # Clients
-        src_dir / 'clients/rtsp_to_http_client.cpp',
-        src_dir / 'clients/rtsp_to_rtsp_client.cpp',
-        # Protocol
-        src_dir / 'protocol/request_parser.cpp',
-        src_dir / 'protocol/rtsp_parser.cpp',
-        src_dir / 'protocol/rtp_pipeline.cpp',
-        # Utils
-        src_dir / 'utils/socket_helper.cpp',
-        src_dir / 'utils/blacklist_checker.cpp',
-        src_dir / 'utils/dns_resolver.cpp',
-        src_dir / 'utils/url_rewriter.cpp',
-        src_dir / 'utils/stun_client.cpp',
-    ),
-    include_directories: include_directories(inc_dir),
+    app_srcs,
+    include_directories: inc,
+    link_with: testable_lib,
     install: true,
     install_dir: 'bin',
     link_args: ldflags,
     dependencies: [atomic_dep],
 )
+
+# Unit tests are opt-in so that release and OpenWrt SDK builds, which never copy
+# the test/ directory, are unaffected.
+if get_option('tests')
+    test_names = [
+        'url_rewriter',
+        'blacklist_checker',
+        'rtsp_parser',
+        'request_parser',
+        'rtp_pipeline',
+        'port_pool',
+        'server_config',
+    ]
+
+    foreach name : test_names
+        test_exe = executable(
+            'test_' + name,
+            'test' / 'unit' / ('test_' + name + '.cpp'),
+            include_directories: [inc, include_directories('test/unit')],
+            link_with: testable_lib,
+            install: false,
+            dependencies: [atomic_dep],
+        )
+        test(name, test_exe, protocol: 'exitcode')
+    endforeach
+
+    test(
+        'install_logic',
+        find_program('sh'),
+        args: [meson.current_source_dir() / 'test' / 'test_install_logic.sh'],
+        protocol: 'exitcode',
+    )
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('isstatic', type: 'boolean', value: false, description: 'Enable static compilation')
+option('tests', type: 'boolean', value: false, description: 'Build the unit test suite')

--- a/src/clients/rtsp_to_http_client.cpp
+++ b/src/clients/rtsp_to_http_client.cpp
@@ -492,7 +492,7 @@ void RTSPToHttpClient::on_rtp_readable()
     {
         if (ServerConfig::isNatEnabled() == true)
         {
-            if (StunClient::extract_stun_mapping_from_response(buf.get(), recv_len, nat_wan_ip, nat_wan_port) == 0)
+            if (StunClient::extract_stun_mapping_from_response(rtp_fd_, buf.get(), recv_len, nat_wan_ip, nat_wan_port) == 0)
             {
                 Logger::debug("[RTP] Extract STUN mapping success: " + nat_wan_ip + ":" + std::to_string(nat_wan_port));
             };

--- a/src/clients/rtsp_to_http_client.cpp
+++ b/src/clients/rtsp_to_http_client.cpp
@@ -152,6 +152,8 @@ void RTSPToHttpClient::handle_client(uint32_t event)
     if (event & EPOLLIN)
     {
         on_client_readable();
+        if (is_closed_)
+            return;
     }
     if (event & EPOLLOUT)
     {
@@ -597,6 +599,30 @@ void RTSPToHttpClient::on_client_writable()
 
 void RTSPToHttpClient::on_client_readable()
 {
+    // Nothing is expected from the client once its request has been dispatched,
+    // but the fd stays armed with EPOLLIN and the loop is level-triggered, so
+    // anything it does send must be drained or epoll_wait spins on it forever.
+    char discard[4096];
+    while (true)
+    {
+        ssize_t n = recv(client_fd_, discard, sizeof(discard), 0);
+        if (n > 0)
+            continue;
+
+        if (n == 0)
+        {
+            on_client_closed();
+            return;
+        }
+
+        if (errno == EINTR)
+            continue;
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+            return;
+
+        on_client_closed();
+        return;
+    }
 }
 
 void RTSPToHttpClient::on_client_closed()

--- a/src/clients/rtsp_to_rtsp_client.cpp
+++ b/src/clients/rtsp_to_rtsp_client.cpp
@@ -313,10 +313,32 @@ std::string RTSPToRtspClient::patch_response_for_client(const std::string &resp)
         // Parse server_port from upstream response and remember it.
         std::regex sp_re(R"(server_port=(\d+)-(\d+))");
         std::smatch sm;
+        uint16_t srv_rtp = 0, srv_rtcp = 0;
+        bool have_server_ports = false;
         if (std::regex_search(transport, sm, sp_re))
         {
-            uint16_t srv_rtp = static_cast<uint16_t>(std::stoi(sm[1]));
-            uint16_t srv_rtcp = static_cast<uint16_t>(std::stoi(sm[2]));
+            try
+            {
+                int parsed_rtp = std::stoi(sm[1]);
+                int parsed_rtcp = std::stoi(sm[2]);
+                if (parsed_rtp >= 1 && parsed_rtp <= 65535 &&
+                    parsed_rtcp >= 1 && parsed_rtcp <= 65535)
+                {
+                    srv_rtp = static_cast<uint16_t>(parsed_rtp);
+                    srv_rtcp = static_cast<uint16_t>(parsed_rtcp);
+                    have_server_ports = true;
+                }
+            }
+            catch (...)
+            {
+            }
+
+            if (!have_server_ports)
+                Logger::warn("[MITM] Ignoring invalid server_port in upstream Transport: " + transport);
+        }
+
+        if (have_server_ports)
+        {
             std::string rtp_source = ctx_.server_ip;
             std::regex source_re(R"(source=([0-9.]+))");
             std::smatch source_match;

--- a/src/clients/rtsp_to_rtsp_client.cpp
+++ b/src/clients/rtsp_to_rtsp_client.cpp
@@ -673,7 +673,7 @@ void RTSPToRtspClient::handle_rtp_from_upstream(uint32_t /*events*/)
         {
             std::string wan_ip;
             uint16_t wan_port = 0;
-            if (StunClient::extract_stun_mapping_from_response(buf.get(), n, wan_ip, wan_port) == 0)
+            if (StunClient::extract_stun_mapping_from_response(rtp_us_fd_, buf.get(), n, wan_ip, wan_port) == 0)
             {
                 nat_wan_port_us_ = wan_port;
                 Logger::debug("[MITM] STUN mapped public port for RTP: " + std::to_string(nat_wan_port_us_));
@@ -1094,7 +1094,14 @@ void RTSPToRtspClient::on_downstream_readable()
         req = rewrite_request_for_upstream(req);
 
         to_upstream_q_.push_back(req);
-        loop_->set(upstream_ctx_.get(), upstream_fd_, EPOLLIN | EPOLLOUT);
+        // finish_upstream_connection() can retire the upstream socket while the
+        // session stays alive, and it leaves upstream_fd_ at -1. Arming epoll on
+        // -1 only earns an EBADF in the log, so mirror the guard handle_timer()
+        // already has and drop the request instead.
+        if (upstream_fd_ >= 0)
+            loop_->set(upstream_ctx_.get(), upstream_fd_, EPOLLIN | EPOLLOUT);
+        else
+            Logger::warn("[MITM] Upstream socket is gone, dropping queued request");
     }
 }
 
@@ -1591,7 +1598,10 @@ void RTSPToRtspClient::process_pending_setup()
     req = rewrite_request_for_upstream(req);
 
     to_upstream_q_.push_back(req);
-    loop_->set(upstream_ctx_.get(), upstream_fd_, EPOLLIN | EPOLLOUT);
+    if (upstream_fd_ >= 0)
+        loop_->set(upstream_ctx_.get(), upstream_fd_, EPOLLIN | EPOLLOUT);
+    else
+        Logger::warn("[MITM] Upstream socket is gone, dropping pending SETUP");
 }
 
 json RTSPToRtspClient::get_info() const

--- a/src/clients/rtsp_to_rtsp_client.cpp
+++ b/src/clients/rtsp_to_rtsp_client.cpp
@@ -1366,8 +1366,12 @@ void RTSPToRtspClient::on_upstream_readable()
             to_upstream_q_.clear();
             upstream_send_offset_ = 0;
 
-            // Rewrite the original downstream request to point to the new upstream URL
-            std::string rewritten_req = rewrite_request_for_upstream(last_downstream_req_);
+            // Retry the same method and headers against the complete redirect
+            // Location.  Reusing rewrite_request_for_upstream() here only
+            // changed the authority and accidentally retained the old path,
+            // dropping any path/query supplied by the 301/302 response.
+            std::string rewritten_req =
+                rtspParser::replace_request_uri(last_downstream_req_, ctx_.rtsp_url);
             to_upstream_q_.push_back(rewritten_req);
 
             // Connect to the new upstream server

--- a/src/core/epoll_loop.cpp
+++ b/src/core/epoll_loop.cpp
@@ -33,12 +33,22 @@ void EpollLoop::add_task(std::function<void()> task)
 
 void EpollLoop::process_tasks()
 {
-    std::lock_guard<std::mutex> lock(task_queue_mutex_);
-
-    while (!task_queue_.empty())
+    // Take the queue and drop the lock before running anything. Tasks are free
+    // to call add_task() (a session tearing itself down queues follow-up work),
+    // and std::mutex is not recursive, so running them under the lock would
+    // deadlock the only thread. Draining into a local also stops a task that
+    // enqueues unconditionally from looping here forever -- its new work runs
+    // on the next pass of the event loop.
+    std::queue<std::function<void()>> pending;
     {
-        auto task = task_queue_.front();
-        task_queue_.pop();
+        std::lock_guard<std::mutex> lock(task_queue_mutex_);
+        pending.swap(task_queue_);
+    }
+
+    while (!pending.empty())
+    {
+        auto task = std::move(pending.front());
+        pending.pop();
         task();
     }
 }

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -4,6 +4,9 @@
 #include <ctime>
 #include <sstream>
 #include <iomanip>
+#include <cerrno>
+#include <fcntl.h>
+#include <unistd.h>
 #include <sys/stat.h>
 
 LogLevel Logger::currentLevel = LogLevel::INFO;
@@ -13,6 +16,38 @@ std::string Logger::logFilePath;
 size_t Logger::maxLogLines = 10000; // Default 10000 lines
 size_t Logger::currentLogLines = 0;
 std::deque<std::string> Logger::logBuffer;
+int Logger::emergencyFd = -1;
+
+void Logger::emergency(const char *msg)
+{
+    if (msg == nullptr)
+        return;
+
+    size_t len = 0;
+    while (msg[len] != '\0')
+        ++len;
+
+    const int targets[2] = {emergencyFd, STDERR_FILENO};
+    for (int fd : targets)
+    {
+        if (fd < 0)
+            continue;
+
+        size_t written = 0;
+        while (written < len)
+        {
+            ssize_t n = write(fd, msg + written, len - written);
+            if (n > 0)
+            {
+                written += static_cast<size_t>(n);
+                continue;
+            }
+            if (n < 0 && errno == EINTR)
+                continue;
+            break; // Nothing useful left to do inside a signal handler.
+        }
+    }
+}
 
 void Logger::setLogLevel(LogLevel level)
 {
@@ -35,7 +70,12 @@ void Logger::setLogFile(const std::string &path, size_t maxLines)
     if (logFile.is_open()) {
         logFile.close();
     }
-    
+
+    if (emergencyFd >= 0) {
+        close(emergencyFd);
+        emergencyFd = -1;
+    }
+
     if (!path.empty()) {
         size_t last_slash = path.find_last_of("/");
         if (last_slash != std::string::npos) {
@@ -52,6 +92,11 @@ void Logger::setLogFile(const std::string &path, size_t maxLines)
         if (!logFile.is_open()) {
             std::cerr << "[LOGGER] Failed to open log file: " << path << std::endl;
         }
+
+        // A second, raw handle on the same file. O_APPEND makes each write
+        // land at the end regardless of what the ofstream has buffered, and
+        // it is the only way to record anything from a signal handler.
+        emergencyFd = open(path.c_str(), O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0644);
     }
 }
 

--- a/src/core/port_pool.cpp
+++ b/src/core/port_pool.cpp
@@ -36,6 +36,7 @@ uint16_t PortPool::acquire_pair()
         {
             used_ports_.insert(p);
             used_ports_.insert(p + 1);
+            allocated_bases_.insert(p);
             return p;
         }
 
@@ -52,8 +53,27 @@ void PortPool::release_pair(uint16_t port)
     if (port == 0) return;
     
     std::lock_guard<std::mutex> lock(mutex_);
+
+    // Only the even RTP port of a pair owns the pair. Releasing the odd half
+    // would free one port of the pair below and one of the pair above, handing
+    // a live pair to a second session.
+    if (port % 2 != 0)
+    {
+        Logger::warn("[PortPool] Ignoring release of odd port " + std::to_string(port) +
+                     ", expected the even RTP port of the pair");
+        return;
+    }
+
+    if (allocated_bases_.erase(port) == 0)
+    {
+        Logger::warn("[PortPool] Ignoring release of port pair " + std::to_string(port) +
+                     ", not allocated by this pool");
+        return;
+    }
+
+    // port is even here, so port + 1 cannot exceed UINT16_MAX and wrap to 0.
     used_ports_.erase(port);
-    used_ports_.erase(port + 1);
+    used_ports_.erase(static_cast<uint16_t>(port + 1));
 }
 
 void PortPool::mark_occupied(uint16_t port)

--- a/src/core/port_pool.cpp
+++ b/src/core/port_pool.cpp
@@ -13,9 +13,33 @@ PortPool::PortPool()
     next_port_ = start_port_;
 }
 
+void PortPool::purge_expired_marks()
+{
+    auto now = std::chrono::steady_clock::now();
+    for (auto it = occupied_marks_.begin(); it != occupied_marks_.end();)
+    {
+        if (now - it->second < kOccupiedTtl)
+        {
+            ++it;
+            continue;
+        }
+
+        // Never un-block a port that is now part of a live allocation: the mark
+        // and the allocation are independent, and dropping it from used_ports_
+        // here would let the pair be handed out a second time.
+        uint16_t base = static_cast<uint16_t>(it->first & ~1u);
+        if (allocated_bases_.find(base) == allocated_bases_.end())
+            used_ports_.erase(it->first);
+
+        it = occupied_marks_.erase(it);
+    }
+}
+
 uint16_t PortPool::acquire_pair()
 {
     std::lock_guard<std::mutex> lock(mutex_);
+
+    purge_expired_marks();
 
     uint16_t attempts = 0;
     uint16_t total_ports = end_port_ - start_port_;
@@ -74,13 +98,27 @@ void PortPool::release_pair(uint16_t port)
     // port is even here, so port + 1 cannot exceed UINT16_MAX and wrap to 0.
     used_ports_.erase(port);
     used_ports_.erase(static_cast<uint16_t>(port + 1));
+
+    // A half of this pair may also be blocked because a foreign process holds
+    // it. Releasing the allocation must not silently clear that block.
+    auto now = std::chrono::steady_clock::now();
+    for (uint16_t p : {port, static_cast<uint16_t>(port + 1)})
+    {
+        auto it = occupied_marks_.find(p);
+        if (it == occupied_marks_.end())
+            continue;
+        if (now - it->second < kOccupiedTtl)
+            used_ports_.insert(p);
+        else
+            occupied_marks_.erase(it);
+    }
 }
 
 void PortPool::mark_occupied(uint16_t port)
 {
     std::lock_guard<std::mutex> lock(mutex_);
     used_ports_.insert(port);
-    // We don't automatically release it, but it will be skipped.
-    // In a real system, we might want a timer to clear these, 
-    // but for now, we just skip it to avoid immediate re-collision.
+    // Re-stamping on every failed bind keeps a port that is still genuinely
+    // taken blocked, while one that was only briefly busy ages out.
+    occupied_marks_[port] = std::chrono::steady_clock::now();
 }

--- a/src/core/proxy_server.cpp
+++ b/src/core/proxy_server.cpp
@@ -8,33 +8,112 @@
 #include <getopt.h>
 #include <sys/wait.h>
 #include <cstring>
+#include <ctime>
 #include <signal.h>
 #include <unistd.h>
 
-static pid_t worker_pid = 0;
+static volatile sig_atomic_t worker_pid = 0;
+
+// Everything below runs in signal context, where the only tools available are
+// async-signal-safe calls. Logger::info()/error()/flush() are none of those:
+// they allocate, touch iostreams, and take a mutex. A crash signal raised while
+// the loop was inside the logger would deadlock the handler, leaving the worker
+// hung rather than dead -- and the supervisor's blocking waitpid() would then
+// never return to restart it. Logger::emergency() is a bare write(2).
+static const char *signal_name(int sig)
+{
+    switch (sig)
+    {
+    case SIGINT:  return "SIGINT";
+    case SIGTERM: return "SIGTERM";
+    case SIGSEGV: return "SIGSEGV";
+    case SIGABRT: return "SIGABRT";
+    case SIGFPE:  return "SIGFPE";
+    case SIGILL:  return "SIGILL";
+    default:      return "an unexpected signal";
+    }
+}
 
 static void worker_sig_handler(int sig)
 {
-    Logger::info("[SERVER] Worker received signal " + std::to_string(sig) + ". Exiting...");
-    Logger::flush();
+    Logger::emergency("[SERVER] Worker received ");
+    Logger::emergency(signal_name(sig));
+    Logger::emergency(". Exiting...\n");
     _exit(0);
 }
 
 static void supervisor_sig_handler(int sig)
 {
-    Logger::info("[SUPERVISOR] Received signal " + std::to_string(sig) + ". Killing worker and exiting...");
+    Logger::emergency("[SUPERVISOR] Received ");
+    Logger::emergency(signal_name(sig));
+    Logger::emergency(". Killing worker and exiting...\n");
     if (worker_pid > 0)
     {
-        kill(worker_pid, SIGTERM);
+        kill(static_cast<pid_t>(worker_pid), SIGTERM);
     }
     _exit(0);
 }
 
 static void crash_handler(int sig)
 {
-    Logger::error("[SERVER] CRITICAL: Worker process crashed with signal " + std::to_string(sig));
-    Logger::flush();
+    Logger::emergency("[SERVER] CRITICAL: Worker process crashed with ");
+    Logger::emergency(signal_name(sig));
+    Logger::emergency("\n");
     _exit(sig);
+}
+
+// Held open from startup for the sole purpose of surviving EMFILE. With the
+// descriptor table full, accept() cannot dequeue the pending connection, and the
+// listen socket is non-blocking and registered level-triggered, so epoll_wait
+// would hand it back immediately, forever, and burn the only thread at 100% CPU.
+// Closing this reserve frees exactly one slot: enough to accept the connection
+// and drop it, which clears the readable condition and lets the loop breathe.
+static int emfile_reserve_fd = -1;
+
+// A descriptor shortage is usually a flood, and every log line costs a
+// mutex-held flush, so report it at most once per interval with a tally.
+static void log_fd_exhaustion(const char *what)
+{
+    static time_t last_report = 0;
+    static unsigned long suppressed = 0;
+
+    time_t now = time(nullptr);
+    if (last_report != 0 && now - last_report < 5)
+    {
+        ++suppressed;
+        return;
+    }
+
+    std::string msg = "[SERVER] Out of file descriptors, " + std::string(what);
+    if (suppressed > 0)
+        msg += " (" + std::to_string(suppressed) + " similar events suppressed)";
+    Logger::error(msg);
+
+    last_report = now;
+    suppressed = 0;
+}
+
+// Dequeue and immediately drop one pending connection so that the listen fd
+// stops being readable. Returns false when no descriptor could be spared, in
+// which case the caller must not simply spin.
+static bool drop_pending_connection(int listen_fd)
+{
+    if (emfile_reserve_fd < 0)
+        return false;
+
+    close(emfile_reserve_fd);
+    emfile_reserve_fd = -1;
+
+    sockaddr_in victim_addr{};
+    socklen_t victim_len = sizeof(victim_addr);
+    int victim_fd = accept(listen_fd, (sockaddr *)&victim_addr, &victim_len);
+    if (victim_fd >= 0)
+        close(victim_fd);
+
+    // Re-arm the reserve for next time. If even this fails the table is still
+    // full; the next EMFILE takes the throttled path below instead.
+    emfile_reserve_fd = open("/dev/null", O_RDONLY | O_CLOEXEC);
+    return victim_fd >= 0;
 }
 
 ProxyServer::ProxyServer() {}
@@ -161,6 +240,15 @@ void ProxyServer::setup_signals()
 
 void ProxyServer::setup_accept_handler(int listen_fd, EpollLoop &loop, BufferPool &pool)
 {
+    // Claim the EMFILE reserve now, after any daemon() call has already taken
+    // over 0/1/2, so that a descriptor is genuinely available later.
+    if (emfile_reserve_fd < 0)
+    {
+        emfile_reserve_fd = open("/dev/null", O_RDONLY | O_CLOEXEC);
+        if (emfile_reserve_fd < 0)
+            Logger::warn("[SERVER] Could not reserve a spare fd; accept() will throttle instead of shedding under fd exhaustion");
+    }
+
     auto accept_handler = [listen_fd, &loop, &pool](uint32_t events)
     {
         [[maybe_unused]] uint32_t unused_events = events;
@@ -171,11 +259,39 @@ void ProxyServer::setup_accept_handler(int listen_fd, EpollLoop &loop, BufferPoo
             int client_fd = accept(listen_fd, (sockaddr *)&client_addr, &len);
             if (client_fd < 0)
             {
+                // Backlog drained: the only condition that should end the batch
+                // quietly, because it is the only one that clears the readable
+                // state of a level-triggered listen fd.
                 if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+
+                // Interrupted, or the peer went away between the SYN and here.
+                // The connection behind it is still queued, so keep going --
+                // returning here would leave the fd readable and spin.
+                if (errno == EINTR || errno == ECONNABORTED) continue;
+
+                if (errno == EMFILE || errno == ENFILE ||
+                    errno == ENOBUFS || errno == ENOMEM)
+                {
+                    if (drop_pending_connection(listen_fd))
+                    {
+                        log_fd_exhaustion("dropped a pending connection");
+                    }
+                    else
+                    {
+                        // No descriptor to spare, so the connection cannot be
+                        // dequeued and the fd stays readable. Sleeping caps the
+                        // damage at a few wakeups per second instead of a full
+                        // core until an existing session frees a descriptor.
+                        log_fd_exhaustion("cannot accept, throttling");
+                        usleep(50 * 1000);
+                    }
+                    break;
+                }
+
                 Logger::error("[SERVER] Accept client request failed: " + std::string(strerror(errno)));
                 break;
             }
-            
+
             fcntl(client_fd, F_SETFL, O_NONBLOCK);
             set_tcp_nodelay(client_fd);
 

--- a/src/core/server_config.cpp
+++ b/src/core/server_config.cpp
@@ -67,8 +67,17 @@ void ServerConfig::parseCommandLine(int argc, char *argv[])
         }
     }
 
-    // Load from file if exists
-    loadFromFile(getJsonPath());
+    // Load from file if exists. A file that is there but unusable stays fatal:
+    // starting up with the operator's auth token and blacklist silently missing
+    // would be worse than not starting at all. A file that is simply absent is
+    // not an error, the compiled-in defaults and the CLI options cover it.
+    {
+        std::ifstream probe(getJsonPath());
+        bool present = probe.is_open();
+        probe.close();
+        if (!loadFromFile(getJsonPath()) && present)
+            throw std::runtime_error("config file '" + getJsonPath() + "' was rejected, see the log for the offending setting");
+    }
 
     // Second pass to override with CLI options
     optind = 1; // Reset getopt
@@ -343,48 +352,123 @@ bool ServerConfig::loadFromFile(const std::string &path)
         return false;
     }
 
+    // Nothing below is committed to global state until the settings block has
+    // been applied in full, so a file rejected halfway leaves the process
+    // exactly as it was.
+    bool has_blacklist = false;
+    std::vector<std::string> bl;
     if (config.contains("blacklist") && config["blacklist"].is_array())
     {
-        std::vector<std::string> bl;
+        has_blacklist = true;
         for (const auto &item : config["blacklist"])
         {
             if (item.is_string()) bl.push_back(item.get<std::string>());
         }
-        setBlacklist(bl);
     }
 
     if (config.contains("settings") && config["settings"].is_object())
     {
         const auto& s = config["settings"];
-        if (s.contains("port")) setPort(s["port"].get<int>());
-        if (s.contains("nat_method")) setNatMethod(s["nat_method"].get<std::string>());
-        if (s.contains("enable_nat")) setNatEnabled(s["enable_nat"].get<bool>());
-        if (s.contains("buffer_pool_count")) setBufferPoolCount(s["buffer_pool_count"].get<int>());
-        if (s.contains("buffer_pool_block_size")) setBufferPoolBlockSize(s["buffer_pool_block_size"].get<int>());
-        if (s.contains("auth_token")) setToken(s["auth_token"].get<std::string>());
-        if (s.contains("log_file")) setLogFile(s["log_file"].get<std::string>());
-        if (s.contains("log_lines")) setLogLines(s["log_lines"].get<size_t>());
-        if (s.contains("log_level")) {
-            std::string level = s["log_level"].get<std::string>();
-            if (level == "error") Logger::setLogLevel(LogLevel::ERROR);
-            else if (level == "warn") Logger::setLogLevel(LogLevel::WARN);
-            else if (level == "info") Logger::setLogLevel(LogLevel::INFO);
-            else if (level == "debug") Logger::setLogLevel(LogLevel::DEBUG);
+
+        // The setters double as the validators, so a bad key is only found
+        // after the keys before it have already been stored. Keep the previous
+        // values so they can be put back verbatim.
+        const int old_port = port;
+        const bool old_enable_nat = enable_nat;
+        const std::string old_nat_method = nat_method;
+        const int old_buffer_pool_count = buffer_pool_count;
+        const int old_buffer_pool_block_size = buffer_pool_block_size;
+        const int old_stun_server_port = stun_server_port;
+        const std::string old_stun_server_host = stun_server_host;
+        const std::string old_auth_token = auth_token;
+        const std::string old_http_upstream_interface = http_upstream_interface;
+        const std::string old_mitm_upstream_interface = mitm_upstream_interface;
+        const std::string old_listen_interface = listen_interface;
+        const std::string old_log_file_path = log_file_path;
+        const size_t old_log_file_lines = log_file_lines;
+        const LogLevel old_log_level = Logger::getLogLevel();
+        const bool old_strip_padding = strip_padding;
+        const bool old_wait_keyframe = wait_keyframe;
+        const bool old_watchdog_enabled = watchdog_enabled;
+        const bool old_daemon_enabled = daemon_enabled;
+
+        // Names the key currently being applied, so a failure can point the
+        // operator at the exact line of their config file.
+        std::string key;
+        try {
+            key = "port";                   if (s.contains(key)) setPort(s[key].get<int>());
+            key = "nat_method";             if (s.contains(key)) setNatMethod(s[key].get<std::string>());
+            key = "enable_nat";             if (s.contains(key)) setNatEnabled(s[key].get<bool>());
+            key = "buffer_pool_count";      if (s.contains(key)) setBufferPoolCount(s[key].get<int>());
+            key = "buffer_pool_block_size"; if (s.contains(key)) setBufferPoolBlockSize(s[key].get<int>());
+            key = "auth_token";             if (s.contains(key)) setToken(s[key].get<std::string>());
+            key = "log_file";               if (s.contains(key)) setLogFile(s[key].get<std::string>());
+            key = "log_lines";              if (s.contains(key)) setLogLines(s[key].get<size_t>());
+            key = "log_level";
+            if (s.contains(key)) {
+                std::string level = s[key].get<std::string>();
+                if (level == "error") Logger::setLogLevel(LogLevel::ERROR);
+                else if (level == "warn") Logger::setLogLevel(LogLevel::WARN);
+                else if (level == "info") Logger::setLogLevel(LogLevel::INFO);
+                else if (level == "debug") Logger::setLogLevel(LogLevel::DEBUG);
+            }
+            key = "strip_padding";          if (s.contains(key)) setStripPadding(s[key].get<bool>());
+            key = "wait_keyframe";          if (s.contains(key)) setWaitKeyframe(s[key].get<bool>());
+            key = "watchdog";               if (s.contains(key)) setWatchdogEnabled(s[key].get<bool>());
+            key = "daemon";                 if (s.contains(key)) setDaemonEnabled(s[key].get<bool>());
+            key = "http_interface";         if (s.contains(key)) setHttpUpstreamInterface(s[key].get<std::string>());
+            key = "mitm_interface";         if (s.contains(key)) setMitmUpstreamInterface(s[key].get<std::string>());
+            key = "listen_interface";       if (s.contains(key)) setListenInterface(s[key].get<std::string>());
+            key = "stun_host";              if (s.contains(key)) setStunHost(s[key].get<std::string>());
+            key = "stun_port";              if (s.contains(key)) setStunPort(s[key].get<int>());
+        } catch (const std::exception& e) {
+            port = old_port;
+            enable_nat = old_enable_nat;
+            nat_method = old_nat_method;
+            buffer_pool_count = old_buffer_pool_count;
+            buffer_pool_block_size = old_buffer_pool_block_size;
+            stun_server_port = old_stun_server_port;
+            stun_server_host = old_stun_server_host;
+            auth_token = old_auth_token;
+            http_upstream_interface = old_http_upstream_interface;
+            mitm_upstream_interface = old_mitm_upstream_interface;
+            listen_interface = old_listen_interface;
+            log_file_path = old_log_file_path;
+            log_file_lines = old_log_file_lines;
+            Logger::setLogLevel(old_log_level);
+            strip_padding = old_strip_padding;
+            wait_keyframe = old_wait_keyframe;
+            watchdog_enabled = old_watchdog_enabled;
+            daemon_enabled = old_daemon_enabled;
+            Logger::error("[CONFIG] Bad value for setting '" + key + "': " + std::string(e.what()));
+            return false;
         }
-        if (s.contains("strip_padding")) setStripPadding(s["strip_padding"].get<bool>());
-        if (s.contains("wait_keyframe")) setWaitKeyframe(s["wait_keyframe"].get<bool>());
-        if (s.contains("watchdog")) setWatchdogEnabled(s["watchdog"].get<bool>());
-        if (s.contains("daemon")) setDaemonEnabled(s["daemon"].get<bool>());
-        if (s.contains("http_interface")) setHttpUpstreamInterface(s["http_interface"].get<std::string>());
-        if (s.contains("mitm_interface")) setMitmUpstreamInterface(s["mitm_interface"].get<std::string>());
-        if (s.contains("listen_interface")) setListenInterface(s["listen_interface"].get<std::string>());
-        if (s.contains("stun_host")) setStunHost(s["stun_host"].get<std::string>());
-        if (s.contains("stun_port")) setStunPort(s["stun_port"].get<int>());
     }
+
+    if (has_blacklist) setBlacklist(bl);
 
     if (config.contains("replace_templates") && config["replace_templates"].is_array())
     {
-        URLRewriter::set_replace_templates(config["replace_templates"]);
+        // A rule without a string action/match can never fire, so drop it here
+        // rather than letting rewrite_path complain on every single request.
+        nlohmann::json templates = nlohmann::json::array();
+        size_t index = 0;
+        for (const auto &tpl : config["replace_templates"])
+        {
+            if (!tpl.is_object() ||
+                !tpl.contains("action") || !tpl["action"].is_string() ||
+                !tpl.contains("match") || !tpl["match"].is_string())
+            {
+                Logger::warn("[CONFIG] Ignoring replace_templates[" + std::to_string(index) +
+                             "]: needs a string 'action' and a string 'match'");
+            }
+            else
+            {
+                templates.push_back(tpl);
+            }
+            ++index;
+        }
+        URLRewriter::set_replace_templates(templates);
     }
 
     return true;

--- a/src/handlers/api_handle.cpp
+++ b/src/handlers/api_handle.cpp
@@ -124,6 +124,10 @@ bool ApiHandle::dispatch(int client_fd, const RequestInfo &info, EpollLoop *loop
             send_json_response(client_fd, response, loop);
             return true;
         }
+
+        std::string resp = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
+        send_response(loop, client_fd, std::move(resp));
+        return true;
     }
 
     if (is_admin)
@@ -144,8 +148,14 @@ void ApiHandle::serve_admin_file(int client_fd, const RequestInfo &info, EpollLo
 
     if (clean_path == "/admin")
     {
+        // Redirect from the raw URI so the token survives the hop
+        std::string query;
+        size_t raw_query_pos = info.raw_uri.find('?');
+        if (raw_query_pos != std::string::npos)
+            query = info.raw_uri.substr(raw_query_pos);
+
         std::string response = "HTTP/1.1 301 Moved Permanently\r\n"
-                               "Location: /admin/\r\n"
+                               "Location: /admin/" + query + "\r\n"
                                "Content-Length: 0\r\n"
                                "Connection: close\r\n"
                                "\r\n";
@@ -214,7 +224,6 @@ void ApiHandle::send_json_response(int client_fd, const json &j, EpollLoop *loop
     std::string header = "HTTP/1.1 200 OK\r\n"
                          "Content-Type: application/json\r\n"
                          "Content-Length: " + std::to_string(body.size()) + "\r\n"
-                         "Access-Control-Allow-Origin: *\r\n"
                          "Connection: close\r\n"
                          "\r\n";
     send_response(loop, client_fd, header + body);

--- a/src/handlers/rtsp_to_rtsp_handle.cpp
+++ b/src/handlers/rtsp_to_rtsp_handle.cpp
@@ -14,22 +14,20 @@ bool RtspToRtspHandle::dispatch(int client_fd, const sockaddr_in &client_addr, c
     std::string client_host = std::string(inet_ntoa(client_addr.sin_addr)) + ":" + std::to_string(ntohs(client_addr.sin_port));
     
     try {
-        rtspCtx ctx;
-        if (rtspParser::parse_url(info.upstream_url, ctx) != 0) {
-            throw std::runtime_error("Failed to parse RTSP URL: " + info.upstream_url);
-        }
+        // Resolve once, then audit the exact context the client will connect with:
+        // a second parse would re-resolve DNS and could yield a different address.
+        auto config = RTSPToRtspClient::resolve_upstream(raw_request);
 
         // Security Audit
-        if (BlacklistChecker::is_blacklisted(ctx.server_ip)) {
-            throw std::runtime_error("Upstream " + ctx.server_ip + " is blacklisted.");
+        if (BlacklistChecker::is_blacklisted(config.ctx.server_ip)) {
+            throw std::runtime_error("Upstream " + config.ctx.server_ip + " is blacklisted.");
         }
-        if (BlacklistChecker::is_loopback(ctx.server_ip, ctx.server_rtsp_port, client_fd)) {
+        if (BlacklistChecker::is_loopback(config.ctx.server_ip, config.ctx.server_rtsp_port, client_fd)) {
             throw std::runtime_error("Recursive connection detected.");
         }
 
         Logger::debug("[RTSP2RTSP] Dispatching session: " + client_host + " -> " + info.upstream_url);
-        
-        auto config = RTSPToRtspClient::resolve_upstream(raw_request);
+
         auto client = std::make_unique<RTSPToRtspClient>(loop, pool, client_addr, client_fd, config, raw_request);
         loop->add_client_to_map(client_fd, std::move(client));
 

--- a/src/protocol/request_parser.cpp
+++ b/src/protocol/request_parser.cpp
@@ -2,6 +2,7 @@
 #include "core/server_config.h"
 #include "utils/url_rewriter.h"
 #include <cstdio>
+#include <sstream>
 
 static std::string sanitize_input(const std::string &s)
 {

--- a/src/protocol/request_parser.cpp
+++ b/src/protocol/request_parser.cpp
@@ -25,12 +25,34 @@ static std::string sanitize_input(const std::string &s)
     return result;
 }
 
+// Clean up a URI: remove backslashes (escaping)
+static void strip_backslashes(std::string &s)
+{
+    size_t pos;
+    while ((pos = s.find("%5C")) != std::string::npos) {
+        s.replace(pos, 3, "");
+    }
+    while ((pos = s.find("%5c")) != std::string::npos) {
+        s.replace(pos, 3, "");
+    }
+    while ((pos = s.find('\\')) != std::string::npos) {
+        s.replace(pos, 1, "");
+    }
+}
+
 RequestInfo RequestParser::parse(const std::string &request_data)
 {
     RequestInfo info;
     std::istringstream ss(request_data);
     if (!(ss >> info.method >> info.raw_uri >> info.version))
     {
+        // The chained extraction has already written whatever it could read, so
+        // those bytes still reach the caller (and its log line) and must be
+        // cleaned here too.
+        info.method = sanitize_input(info.method);
+        info.version = sanitize_input(info.version);
+        strip_backslashes(info.raw_uri);
+        info.raw_uri = sanitize_input(info.raw_uri);
         return info;
     }
 
@@ -38,18 +60,7 @@ RequestInfo RequestParser::parse(const std::string &request_data)
     info.version = sanitize_input(info.version);
     info.is_http = (info.version.find("HTTP/") == 0);
 
-    // Clean up info.raw_uri: remove backslashes (escaping)
-    size_t pos;
-    while ((pos = info.raw_uri.find("%5C")) != std::string::npos) {
-        info.raw_uri.replace(pos, 3, "");
-    }
-    while ((pos = info.raw_uri.find("%5c")) != std::string::npos) {
-        info.raw_uri.replace(pos, 3, "");
-    }
-    while ((pos = info.raw_uri.find('\\')) != std::string::npos) {
-        info.raw_uri.replace(pos, 1, "");
-    }
-
+    strip_backslashes(info.raw_uri);
     info.raw_uri = sanitize_input(info.raw_uri);
     if (ServerConfig::getToken().empty())
     {
@@ -101,12 +112,21 @@ RequestInfo RequestParser::parse(const std::string &request_data)
         }
     }
 
-    size_t path_start = info.clean_uri.find("/rtp/");
-    if (path_start == std::string::npos) {
-        path_start = info.clean_uri.find("/tv/");
+    // The prefix test has to be anchored at the start of the path, otherwise a
+    // "/rtp/" or "/tv/" sitting in a query string (or deeper inside an unrelated
+    // path) would pick the upstream host. RTSP clients may send an absolute URI,
+    // so skip the scheme and authority when the request line carries one.
+    size_t query_start = info.clean_uri.find('?');
+    size_t path_start = 0;
+    size_t scheme_end = info.clean_uri.find("://");
+    if (scheme_end != std::string::npos &&
+        (query_start == std::string::npos || scheme_end < query_start)) {
+        path_start = info.clean_uri.find('/', scheme_end + 3);
     }
 
-    if (path_start != std::string::npos) {
+    if (path_start != std::string::npos &&
+        (info.clean_uri.compare(path_start, 5, "/rtp/") == 0 ||
+         info.clean_uri.compare(path_start, 4, "/tv/") == 0)) {
         std::string sub_path = info.clean_uri.substr(path_start);
         URLRewriter::rewrite_path(sub_path, info.upstream_url);
     }

--- a/src/protocol/rtp_pipeline.cpp
+++ b/src/protocol/rtp_pipeline.cpp
@@ -13,6 +13,7 @@ RtpPipeline::~RtpPipeline() = default;
 
 void RtpPipeline::reset() {
     wait_for_keyframe_ = ServerConfig::isWaitKeyframe();
+    dropped_while_waiting_ = 0;
 }
 
 bool RtpPipeline::process(uint8_t *buf, size_t &len) {
@@ -21,7 +22,13 @@ bool RtpPipeline::process(uint8_t *buf, size_t &len) {
     // 1. Startup Keyframe Sync
     if (unlikely(wait_for_keyframe_)) {
         if (check_keyframe(buf, len)) {
-            Logger::debug("[Pipeline] Keyframe/PAT found, start forwarding");
+            Logger::debug("[Pipeline] Keyframe found, start forwarding");
+            wait_for_keyframe_ = false;
+        } else if (unlikely(++dropped_while_waiting_ >= KEYFRAME_WAIT_LIMIT)) {
+            // Codecs we cannot parse (or scrambled payloads) would otherwise keep
+            // the gate shut forever, so give up and start forwarding anyway.
+            Logger::debug("[Pipeline] No keyframe after " + std::to_string(KEYFRAME_WAIT_LIMIT) +
+                          " packets, start forwarding anyway");
             wait_for_keyframe_ = false;
         } else {
             return false; // Drop until keyframe
@@ -63,14 +70,16 @@ void RtpPipeline::strip_rtp_padding_and_ts_null(uint8_t *buf, size_t &len) {
             uint8_t padding_len = buf[len - 1];
             if (likely(padding_len > 0 && padding_len <= (len - payload_offset))) {
                 len -= padding_len;
+                buf[0] &= ~0x20; // Clear padding bit only once the padding is really gone
             }
-            buf[0] &= ~0x20; // Clear padding bit
         }
 
         // 2. Strip TS Null Packets (PID 0x1FFF)
         size_t payload_len = len - payload_offset;
         // Check if it's MPEG-TS (starts with 0x47)
         if (likely(payload_len >= 188 && buf[payload_offset] == 0x47)) {
+            size_t whole_len = payload_len - (payload_len % 188);
+            size_t tail_len = payload_len - whole_len;
             size_t new_payload_len = 0;
             for (size_t i = 0; i + 188 <= payload_len; i += 188) {
                 uint16_t pid = ((buf[payload_offset + i + 1] & 0x1F) << 8) | buf[payload_offset + i + 2];
@@ -81,10 +90,13 @@ void RtpPipeline::strip_rtp_padding_and_ts_null(uint8_t *buf, size_t &len) {
                     new_payload_len += 188;
                 }
             }
-            len = payload_offset + new_payload_len;
-            if (new_payload_len == 0) len = 0;
-            
-            buf[0] &= ~0x20; // Ensure padding bit is clear if we modified the packet
+            // A trailing partial TS packet is not ours to drop, keep it after the
+            // compacted packets.
+            if (unlikely(tail_len > 0 && new_payload_len != whole_len)) {
+                memmove(buf + payload_offset + new_payload_len, buf + payload_offset + whole_len, tail_len);
+            }
+            len = payload_offset + new_payload_len + tail_len;
+            if (new_payload_len == 0 && tail_len == 0) len = 0;
         }
     }
 }
@@ -96,32 +108,40 @@ bool RtpPipeline::check_keyframe(const uint8_t *buf, size_t len) {
     if (likely(payload_off + 188 <= len && buf[payload_off] == 0x47)) {
         for (size_t i = 0; payload_off + i + 188 <= len; i += 188) {
             const uint8_t *ts = buf + payload_off + i;
-            uint16_t pid = ((ts[1] & 0x1F) << 8) | ts[2];
-            
-            // 1. PAT is a good sync point as headers usually follow
-            if (pid == 0) return true; 
 
-            // 2. Check for Random Access Indicator in Adaptation Field
+            // 1. Check for Random Access Indicator in Adaptation Field
             uint8_t afc = (ts[3] & 0x30) >> 4;
             if (afc >= 2 && ts[4] > 0 && (ts[5] & 0x40)) return true;
 
-            // 3. Deep scan for H.264 NAL units (SPS=7, PPS=8, IDR=5)
+            // 2. Deep scan for H.264 NAL units (SPS=7, PPS=8, IDR=5)
             // This handles cases where RAI bit is not set but headers are present.
-            size_t ts_payload_off = 4;
-            if (afc == 2 || afc == 3) ts_payload_off += 1 + ts[4];
-            if (ts_payload_off < 188) {
-                const uint8_t *data = ts + ts_payload_off;
-                size_t data_len = 188 - ts_payload_off;
-                for (size_t j = 0; j + 4 < data_len; ++j) {
-                    if (data[j] == 0x00 && data[j+1] == 0x00 && data[j+2] == 0x01) {
-                        // H.264 NAL type is in bits 0-4 of the first byte
-                        uint8_t nal_type_h264 = data[j+3] & 0x1F;
-                        if (nal_type_h264 == 7 || nal_type_h264 == 8 || nal_type_h264 == 5) return true;
+            // afc 0 and 2 carry no payload at all, scanning them reads adaptation
+            // stuffing as if it were video.
+            if (afc == 1 || afc == 3) {
+                size_t ts_payload_off = 4;
+                if (afc == 3) ts_payload_off += 1 + ts[4];
+                if (ts_payload_off < 188) {
+                    const uint8_t *data = ts + ts_payload_off;
+                    size_t data_len = 188 - ts_payload_off;
+                    for (size_t j = 0; j + 3 < data_len; ++j) {
+                        if (data[j] == 0x00 && data[j+1] == 0x00 && data[j+2] == 0x01) {
+                            uint8_t nal_hdr = data[j+3];
+                            // forbidden_zero_bit must be 0 in both codecs; when it is set
+                            // this is a PES header (stream_id 0x80-0xFF), not a NAL unit.
+                            if (nal_hdr & 0x80) continue;
 
-                        // H.265 NAL type is in bits 1-6 of the first byte
-                        uint8_t nal_type_h265 = (data[j+3] >> 1) & 0x3F;
-                        if (nal_type_h265 >= 32 && nal_type_h265 <= 34) return true; // VPS, SPS, PPS
-                        if (nal_type_h265 == 19 || nal_type_h265 == 20) return true; // IDR
+                            // H.264 NAL type is in bits 0-4 of the first byte
+                            uint8_t nal_type_h264 = nal_hdr & 0x1F;
+                            if (nal_type_h264 == 7 || nal_type_h264 == 8 || nal_type_h264 == 5) return true;
+
+                            // H.265 NAL type is in bits 1-6 of the first byte
+                            uint8_t nal_type_h265 = (nal_hdr >> 1) & 0x3F;
+                            if (nal_type_h265 == 19 || nal_type_h265 == 20) return true; // IDR
+                            // Type 32-34 alone also matches common H.264 slice headers, so
+                            // demand the second header byte of a base-layer NAL as well.
+                            if (nal_type_h265 >= 32 && nal_type_h265 <= 34 &&
+                                j + 4 < data_len && data[j+4] == 0x01) return true; // VPS, SPS, PPS
+                        }
                     }
                 }
             }

--- a/src/protocol/rtsp_parser.cpp
+++ b/src/protocol/rtsp_parser.cpp
@@ -96,14 +96,17 @@ void rtspParser::SDP::parseMedia(const std::string &line, rtspCtx &ctx)
 
 void rtspParser::SDP::parseAttribute(const std::string &line, Media &media)
 {
-    std::istringstream attr_stream(line.substr(2));
-    std::string key, value;
-    if (std::getline(attr_stream, key, ':') && std::getline(attr_stream, value))
-    {
-        media.attributes[key] = value;
-        if (key == "control")
-            media.trackID = value;
-    }
+    // RFC 4566 allows both "a=<key>:<value>" and the bare property form "a=<key>"
+    std::string attribute = line.substr(2);
+    size_t colon = attribute.find(':');
+    std::string key = attribute.substr(0, colon);
+    std::string value = (colon == std::string::npos) ? std::string() : attribute.substr(colon + 1);
+    if (key.empty())
+        return;
+
+    media.attributes[key] = value;
+    if (key == "control")
+        media.trackID = value;
 }
 
 void rtspParser::SDP::parseBandwidth(const std::string &line, rtspCtx &ctx)
@@ -118,6 +121,32 @@ void rtspParser::SDP::parseBandwidth(const std::string &line, rtspCtx &ctx)
     }
 }
 
+namespace
+{
+
+// A single Transport range endpoint: a decimal number, optionally padded with
+// horizontal whitespace as some servers do.
+bool parse_transport_number(const std::string &text, int &value)
+{
+    try
+    {
+        size_t parsed = 0;
+        int number = std::stoi(text, &parsed);
+        while (parsed < text.size() && (text[parsed] == ' ' || text[parsed] == '\t'))
+            ++parsed;
+        if (parsed != text.size())
+            return false;
+        value = number;
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+} // namespace
+
 int rtspParser::parse_server_ports(const std::string &resp, rtspCtx &ctx)
 {
     std::string transport_ = extract_header_value(resp, "Transport");
@@ -128,52 +157,51 @@ int rtspParser::parse_server_ports(const std::string &resp, rtspCtx &ctx)
     if (sp_pos != std::string::npos)
     {
         sp_pos += strlen("server_port=");
+        // the range must be read from this parameter only, never from a later one
+        size_t sp_end = transport_.find(';', sp_pos);
+        if (sp_end == std::string::npos)
+            sp_end = transport_.size();
         size_t dash = transport_.find('-', sp_pos);
-        if (dash != std::string::npos)
-        {
-            try
-            {
-                int rtp_port = std::stoi(transport_.substr(sp_pos, dash - sp_pos));
-                int rtcp_port = std::stoi(transport_.substr(dash + 1));
-                if (rtp_port < 1 || rtp_port > 65535 ||
-                    rtcp_port < 1 || rtcp_port > 65535)
-                    return -1;
-                ctx.server_rtp_port = static_cast<uint16_t>(rtp_port);
-                ctx.server_rtcp_port = static_cast<uint16_t>(rtcp_port);
-                return 0;
-            }
-            catch (...)
-            {
-                return -1;
-            }
-        }
+        if (dash == std::string::npos || dash >= sp_end)
+            return -1;
+
+        int rtp_port = 0;
+        int rtcp_port = 0;
+        if (!parse_transport_number(transport_.substr(sp_pos, dash - sp_pos), rtp_port) ||
+            !parse_transport_number(transport_.substr(dash + 1, sp_end - dash - 1), rtcp_port))
+            return -1;
+        if (rtp_port < 1 || rtp_port > 65535 ||
+            rtcp_port < 1 || rtcp_port > 65535)
+            return -1;
+        ctx.server_rtp_port = static_cast<uint16_t>(rtp_port);
+        ctx.server_rtcp_port = static_cast<uint16_t>(rtcp_port);
+        return 0;
     }
 
     size_t int_pos = transport_.find("interleaved=");
     if (int_pos != std::string::npos)
     {
         int_pos += strlen("interleaved=");
+        size_t int_end = transport_.find(';', int_pos);
+        if (int_end == std::string::npos)
+            int_end = transport_.size();
         size_t dash = transport_.find('-', int_pos);
-        if (dash != std::string::npos)
-        {
-            // For interleaved mode, we can store channels in port fields
-            // The caller (RTSPToHttpClient) will check for "interleaved" in the string anyway
-            try
-            {
-                int rtp_channel = std::stoi(transport_.substr(int_pos, dash - int_pos));
-                int rtcp_channel = std::stoi(transport_.substr(dash + 1));
-                if (rtp_channel < 0 || rtp_channel > 255 ||
-                    rtcp_channel < 0 || rtcp_channel > 255)
-                    return -1;
-                ctx.server_rtp_port = static_cast<uint16_t>(rtp_channel);
-                ctx.server_rtcp_port = static_cast<uint16_t>(rtcp_channel);
-                return 0;
-            }
-            catch (...)
-            {
-                return -1;
-            }
-        }
+        if (dash == std::string::npos || dash >= int_end)
+            return -1;
+
+        // For interleaved mode, we can store channels in port fields
+        // The caller (RTSPToHttpClient) will check for "interleaved" in the string anyway
+        int rtp_channel = 0;
+        int rtcp_channel = 0;
+        if (!parse_transport_number(transport_.substr(int_pos, dash - int_pos), rtp_channel) ||
+            !parse_transport_number(transport_.substr(dash + 1, int_end - dash - 1), rtcp_channel))
+            return -1;
+        if (rtp_channel < 0 || rtp_channel > 255 ||
+            rtcp_channel < 0 || rtcp_channel > 255)
+            return -1;
+        ctx.server_rtp_port = static_cast<uint16_t>(rtp_channel);
+        ctx.server_rtcp_port = static_cast<uint16_t>(rtcp_channel);
+        return 0;
     }
 
     return -1;

--- a/src/protocol/rtsp_parser.cpp
+++ b/src/protocol/rtsp_parser.cpp
@@ -340,3 +340,22 @@ std::string rtspParser::extract_header_value(const std::string &msg, const std::
         return msg.substr(pos);
     return msg.substr(pos, end - pos);
 }
+
+std::string rtspParser::replace_request_uri(const std::string &request, const std::string &uri)
+{
+    size_t line_end = request.find("\r\n");
+    if (line_end == std::string::npos)
+        return request;
+
+    size_t method_end = request.find(' ');
+    if (method_end == std::string::npos || method_end >= line_end)
+        return request;
+
+    size_t version_start = request.find(' ', method_end + 1);
+    if (version_start == std::string::npos || version_start >= line_end)
+        return request;
+
+    std::string result = request;
+    result.replace(method_end + 1, version_start - method_end - 1, uri);
+    return result;
+}

--- a/src/utils/blacklist_checker.cpp
+++ b/src/utils/blacklist_checker.cpp
@@ -5,12 +5,30 @@
 #include <cstring>
 #include <vector>
 
+namespace
+{
+
+// DNS names are case-insensitive (RFC 4343); IP literals are unaffected by
+// ASCII case folding, so hostname comparisons fold both sides.
+std::string to_lower_ascii(const std::string &s)
+{
+    std::string out = s;
+    for (char &c : out)
+    {
+        if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
+    }
+    return out;
+}
+
+} // namespace
+
 bool BlacklistChecker::is_blacklisted(const std::string &host)
 {
     const auto &blacklist = ServerConfig::getBlacklist();
     if (blacklist.empty()) return false;
 
     auto check_once = [&](const std::string &h) -> bool {
+        const std::string h_lower = to_lower_ascii(h);
         for (const auto &pattern : blacklist)
         {
             if (pattern.find('/') != std::string::npos)
@@ -23,7 +41,7 @@ bool BlacklistChecker::is_blacklisted(const std::string &host)
             }
             else
             {
-                if (h == pattern) return true;
+                if (h_lower == to_lower_ascii(pattern)) return true;
             }
         }
         return false;
@@ -48,11 +66,16 @@ bool BlacklistChecker::match_cidr(const std::string &ip, const std::string &cidr
     if (slash_pos == std::string::npos) return ip == cidr;
 
     std::string base_ip_str = cidr.substr(0, slash_pos);
+    std::string bits_str = cidr.substr(slash_pos + 1);
+    // std::stoi() accepts signs and leading whitespace ("-0" parses as 0 and
+    // would degrade the entry to /0), so require plain decimal digits first.
+    if (bits_str.empty() || bits_str.find_first_not_of("0123456789") != std::string::npos)
+        return false;
+
     int bits = 0;
     try
     {
         size_t parsed = 0;
-        std::string bits_str = cidr.substr(slash_pos + 1);
         bits = std::stoi(bits_str, &parsed);
         if (parsed != bits_str.size() || bits < 0 || bits > 32)
             return false;
@@ -78,27 +101,30 @@ bool BlacklistChecker::match_wildcard(const std::string &host, const std::string
     // We'll support * at the beginning or end.
     if (pattern == "*") return true;
 
-    if (pattern.front() == '*')
+    const std::string h = to_lower_ascii(host);
+    const std::string p = to_lower_ascii(pattern);
+
+    if (p.front() == '*')
     {
-        std::string suffix = pattern.substr(1);
-        if (host.size() >= suffix.size())
+        std::string suffix = p.substr(1);
+        if (h.size() >= suffix.size())
         {
-            return host.compare(host.size() - suffix.size(), suffix.size(), suffix) == 0;
+            return h.compare(h.size() - suffix.size(), suffix.size(), suffix) == 0;
         }
     }
-    else if (pattern.back() == '*')
+    else if (p.back() == '*')
     {
-        std::string prefix = pattern.substr(0, pattern.size() - 1);
-        if (host.size() >= prefix.size())
+        std::string prefix = p.substr(0, p.size() - 1);
+        if (h.size() >= prefix.size())
         {
-            return host.compare(0, prefix.size(), prefix) == 0;
+            return h.compare(0, prefix.size(), prefix) == 0;
         }
     }
     else
     {
         // General case (very simple): split by * and match segments
         // For now, let's just support prefix/suffix for simplicity as requested (*.domain.com)
-        return host == pattern;
+        return h == p;
     }
 
     return false;

--- a/src/utils/socket_helper.cpp
+++ b/src/utils/socket_helper.cpp
@@ -209,12 +209,23 @@ int bind_udp_pair_from_pool(int &rtp_fd, int &rtcp_fd, uint16_t &rtp_port, const
             // RTCP failed, close RTP and mark port as occupied
             close(rtp_fd);
             rtp_fd = -1;
+            // Hand the pair back before blocking the half that some other
+            // process owns. mark_occupied() alone would leave the pool still
+            // counting this pair as allocated, so the pair would be lost for
+            // the lifetime of the process and a client that keeps hitting
+            // taken ports would drain the whole range.
+            pool.release_pair(rtp_port);
             pool.mark_occupied(rtp_port + 1);
         }
         else
         {
+            pool.release_pair(rtp_port);
             pool.mark_occupied(rtp_port);
         }
     }
+
+    // Nothing is bound and nothing is still held; make sure the caller cannot
+    // mistake the last attempted port for one it now owns.
+    rtp_port = 0;
     return -1;
 }

--- a/src/utils/stun_client.cpp
+++ b/src/utils/stun_client.cpp
@@ -3,6 +3,9 @@
 #include <cstring>
 #include <ctime>
 #include <cstdint>
+#include <array>
+#include <map>
+#include <random>
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <unistd.h>
@@ -10,15 +13,39 @@
 #include <sys/time.h>
 
 #define STUN_MSG_BINDING_REQUEST 0x0001
+#define STUN_MSG_BINDING_SUCCESS 0x0101
 #define STUN_ATTR_XOR_MAPPED_ADDR 0x0020
 #define STUN_ATTR_MAPPED_ADDR 0x0001
 #define STUN_MAGIC_COOKIE 0x2112A442
 
+namespace
+{
+
+using TransactionId = std::array<unsigned char, 12>;
+
+// The transaction ID of the request still in flight on each socket. These are
+// media sockets that accept datagrams from anywhere, so without remembering
+// what was asked there is nothing to check an answer against. Bounded by the
+// descriptor high-water mark, and each entry is consumed by the first response
+// examined for that socket.
+std::map<int, TransactionId> &in_flight()
+{
+    static std::map<int, TransactionId> ids;
+    return ids;
+}
+
+} // namespace
+
 void StunClient::gen_tid(unsigned char tid[12])
 {
-    srand(static_cast<unsigned>(time(nullptr)) ^ reinterpret_cast<uintptr_t>(&tid));
+    // Seeded once. The previous code re-seeded srand() from time(nullptr) on
+    // every call, so two requests issued in the same second drew the identical
+    // transaction ID, which defeats the check that now depends on it.
+    static std::mt19937 gen(std::random_device{}());
+    static std::uniform_int_distribution<unsigned> dis(0, 255);
+
     for (int i = 0; i < 12; ++i)
-        tid[i] = rand() & 0xFF;
+        tid[i] = static_cast<unsigned char>(dis(gen));
 }
 
 void StunClient::put16(unsigned char *p, uint16_t v)
@@ -64,29 +91,47 @@ int StunClient::send_stun_mapping_request(int s)
     if (sent != static_cast<ssize_t>(sizeof(req)))
         return -1;
 
+    TransactionId expected;
+    std::memcpy(expected.data(), tid, expected.size());
+    in_flight()[s] = expected;
+
     return 0;
 }
 
-int StunClient::extract_stun_mapping_from_response(unsigned char *rsp, size_t rsp_len, std::string &out_pub_ip, uint16_t &out_pub_port)
+int StunClient::extract_stun_mapping_from_response(int s, unsigned char *rsp, size_t rsp_len, std::string &out_pub_ip, uint16_t &out_pub_port)
 {
+    // One request gets one answer. Consume the record up front so that a packet
+    // which fails any check below cannot be retried against, and so a socket
+    // that never sent a request has nothing to match.
+    auto it = in_flight().find(s);
+    if (it == in_flight().end())
+        return -1;
+    TransactionId expected = it->second;
+    in_flight().erase(it);
+
     if (rsp_len < 20)
         return -1;
 
+    uint16_t msg_type = ntohs(*(uint16_t *)(rsp + 0));
     uint16_t msg_len = ntohs(*(uint16_t *)(rsp + 2));
     uint32_t cookie = ntohl(*(uint32_t *)(rsp + 4));
+
+    // Anything that is not a Binding Success Response carries no mapping: an
+    // error response, or an echoed request, would otherwise be walked for
+    // attributes and could hand back an attacker-chosen address.
+    if (msg_type != STUN_MSG_BINDING_SUCCESS)
+        return -1;
     if (cookie != STUN_MAGIC_COOKIE)
         return -1;
-
-    // We assume transaction ID is correct
-    unsigned char tid[12];
-    std::memcpy(tid, rsp + 8, 12);
+    if (std::memcmp(rsp + 8, expected.data(), expected.size()) != 0)
+        return -1;
 
     size_t offset = 20;
     while (offset + 4 <= 20 + static_cast<size_t>(msg_len) && offset + 4 <= rsp_len)
     {
         uint16_t attr_type = ntohs(*(uint16_t *)(rsp + offset));
         uint16_t attr_len = ntohs(*(uint16_t *)(rsp + offset + 2));
-        uint16_t val_off = offset + 4;
+        size_t val_off = offset + 4;
         if (val_off + attr_len > rsp_len)
             break;
 

--- a/src/utils/url_rewriter.cpp
+++ b/src/utils/url_rewriter.cpp
@@ -13,34 +13,83 @@ void URLRewriter::set_replace_templates(const nlohmann::json &templates)
     replaceTemplates = templates;
 }
 
+namespace
+{
+
+struct Placeholder
+{
+    const char *token;
+    size_t length;
+    const char *group;
+};
+
+// The documented wildcard vocabulary. Everything else in a match pattern is a
+// literal, so it has to be escaped before it reaches std::regex.
+constexpr Placeholder kPlaceholders[] = {
+    {"{number}", 8, "(\\d+)"},
+    {"{word}", 6, "(\\w+)"},
+    {"{any}", 5, "(.*?)"},
+};
+
+const Placeholder *placeholder_at(const std::string &s, size_t pos)
+{
+    for (const auto &ph : kPlaceholders) {
+        if (s.compare(pos, ph.length, ph.token) == 0)
+            return &ph;
+    }
+    return nullptr;
+}
+
+} // namespace
+
 std::string URLRewriter::simplifyToRegex(const std::string &match_pattern)
 {
-    std::string regex_pattern = match_pattern;
+    // Match patterns describe URL query strings, which are full of regex
+    // metacharacters ('?', '.', '+', '('). Escaping everything that is not a
+    // placeholder keeps a natural pattern like "?playseek={number}" from
+    // compiling to an invalid regex.
+    static const std::string metacharacters = "\\^$.|?*+()[]{}";
+
+    std::string regex_pattern;
+    regex_pattern.reserve(match_pattern.size() * 2);
+
     size_t pos = 0;
-    // Each erase length must equal the placeholder's own length and each
-    // advance must equal the replacement's length (5), otherwise the character
-    // after the placeholder is swallowed and an immediately adjacent
-    // placeholder is skipped.
-    while ((pos = regex_pattern.find("{number}", pos)) != std::string::npos) {
-        regex_pattern.replace(pos, 8, "(\\d+)");
-        pos += 5;
-    }
-    pos = 0;
-    while ((pos = regex_pattern.find("{word}", pos)) != std::string::npos) {
-        regex_pattern.replace(pos, 6, "(\\w+)");
-        pos += 5;
-    }
-    pos = 0;
-    while ((pos = regex_pattern.find("{any}", pos)) != std::string::npos) {
-        regex_pattern.replace(pos, 5, "(.*?)");
-        pos += 5;
-    }
-    pos = 0;
-    while ((pos = regex_pattern.find("/", pos)) != std::string::npos) {
-        regex_pattern.replace(pos, 1, "\\/");
-        pos += 2;
+    while (pos < match_pattern.size()) {
+        if (const Placeholder *ph = placeholder_at(match_pattern, pos)) {
+            regex_pattern += ph->group;
+            pos += ph->length;
+            continue;
+        }
+        char c = match_pattern[pos++];
+        if (metacharacters.find(c) != std::string::npos)
+            regex_pattern += '\\';
+        regex_pattern += c;
     }
     return regex_pattern;
+}
+
+std::string URLRewriter::expandReplacement(const std::string &replacement)
+{
+    // std::regex_replace only understands $1/$2 backreferences, but the
+    // documented wildcard syntax is {number}/{word}/{any}, and that is what the
+    // shipped config.json writes in its replacement strings. Bind each
+    // placeholder to the capture group at the same ordinal so both spellings
+    // work.
+    std::string expanded;
+    expanded.reserve(replacement.size());
+
+    int group = 0;
+    size_t pos = 0;
+    while (pos < replacement.size()) {
+        if (const Placeholder *ph = placeholder_at(replacement, pos)) {
+            expanded += '$';
+            expanded += std::to_string(++group);
+            pos += ph->length;
+            continue;
+        }
+        expanded += replacement[pos++];
+    }
+    return expanded;
 }
 
 std::string URLRewriter::shiftTime(const std::string &time_str, int shift_hours)
@@ -84,6 +133,13 @@ bool URLRewriter::rewrite_path(const std::string &url, std::string &rtsp_url)
     // Apply templates for TV URLs (playback links usually have query params)
     if (is_tv && url.find('?') != std::string::npos) {
         for (const auto &template_obj : replaceTemplates) {
+            if (!template_obj.is_object() ||
+                !template_obj.contains("action") || !template_obj["action"].is_string() ||
+                !template_obj.contains("match") || !template_obj["match"].is_string()) {
+                Logger::warn("[REWRITE] Skipping template without a string action/match");
+                continue;
+            }
+
             std::string action = template_obj["action"];
             std::string match_pattern = template_obj["match"];
             std::string regex_pattern = simplifyToRegex(match_pattern);
@@ -92,29 +148,36 @@ bool URLRewriter::rewrite_path(const std::string &url, std::string &rtsp_url)
                 if (action == "remove") {
                     processed_url = std::regex_replace(processed_url, rgx, "");
                 } else if (action == "replace") {
-                    std::string replacement = template_obj["replacement"];
+                    if (!template_obj.contains("replacement") || !template_obj["replacement"].is_string()) {
+                        Logger::warn("[REWRITE] Skipping replace template without a replacement: " + match_pattern);
+                        continue;
+                    }
+                    std::string replacement = expandReplacement(template_obj["replacement"]);
                     processed_url = std::regex_replace(processed_url, rgx, replacement);
                 } else if (action == "timeshift") {
+                    if (!template_obj.contains("shift_hours") || !template_obj["shift_hours"].is_number_integer()) {
+                        Logger::warn("[REWRITE] Skipping timeshift template without shift_hours: " + match_pattern);
+                        continue;
+                    }
                     int shift_hours = template_obj["shift_hours"];
                     std::smatch match;
                     if (std::regex_search(processed_url, match, rgx) && match.size() >= 3) {
-                        std::string start_time = match[1];
-                        std::string end_time = match[2];
-                        std::string new_start = shiftTime(start_time, shift_hours);
-                        std::string new_end = shiftTime(end_time, shift_hours);
-                        
-                        std::string full_match = match[0];
-                        size_t pos1 = full_match.find(start_time);
-                        if (pos1 != std::string::npos) full_match.replace(pos1, start_time.length(), new_start);
-                        size_t pos2 = full_match.find(end_time, pos1 + new_start.length());
-                        if (pos2 != std::string::npos) full_match.replace(pos2, end_time.length(), new_end);
-                        
-                        processed_url.replace(match.position(0), match.length(0), full_match);
+                        std::string new_start = shiftTime(match[1].str(), shift_hours);
+                        std::string new_end = shiftTime(match[2].str(), shift_hours);
+
+                        // Splice by capture-group offset rather than by searching
+                        // for the timestamp text, which would also hit a digit
+                        // belonging to the pattern's own literal part. The later
+                        // group goes first so the earlier edit cannot shift the
+                        // offset that is still needed.
+                        processed_url.replace(match.position(2), match.length(2), new_end);
+                        processed_url.replace(match.position(1), match.length(1), new_start);
                     }
                 }
             } catch (const std::regex_error &e) {
-                Logger::error(std::string("Regex error: ") + e.what());
-                return false;
+                // One malformed rule must not fail the whole request.
+                Logger::error("[REWRITE] Skipping template '" + match_pattern + "': " + e.what());
+                continue;
             }
         }
     }

--- a/src/utils/url_rewriter.cpp
+++ b/src/utils/url_rewriter.cpp
@@ -17,18 +17,22 @@ std::string URLRewriter::simplifyToRegex(const std::string &match_pattern)
 {
     std::string regex_pattern = match_pattern;
     size_t pos = 0;
+    // Each erase length must equal the placeholder's own length and each
+    // advance must equal the replacement's length (5), otherwise the character
+    // after the placeholder is swallowed and an immediately adjacent
+    // placeholder is skipped.
     while ((pos = regex_pattern.find("{number}", pos)) != std::string::npos) {
         regex_pattern.replace(pos, 8, "(\\d+)");
-        pos += 6;
+        pos += 5;
     }
     pos = 0;
     while ((pos = regex_pattern.find("{word}", pos)) != std::string::npos) {
-        regex_pattern.replace(pos, 7, "(\\w+)");
-        pos += 6;
+        regex_pattern.replace(pos, 6, "(\\w+)");
+        pos += 5;
     }
     pos = 0;
     while ((pos = regex_pattern.find("{any}", pos)) != std::string::npos) {
-        regex_pattern.replace(pos, 6, "(.*?)");
+        regex_pattern.replace(pos, 5, "(.*?)");
         pos += 5;
     }
     pos = 0;

--- a/test/unit/test_blacklist_checker.cpp
+++ b/test/unit/test_blacklist_checker.cpp
@@ -153,14 +153,24 @@ int main()
     CHECK_EQ(bl("10.1.2.3"), false);
     set_bl({"10.0.0.0/0x8"});
     CHECK_EQ(bl("10.1.2.3"), false);
+    set_bl({"10.0.0.0/0X8"});
+    CHECK_EQ(bl("10.1.2.3"), false);
 
-    // BUG: std::stoi accepts "-0" as 0, and the (bits < 0) guard does not
-    // reject it, so a malformed prefix silently becomes /0 and blacklists the
-    // entire IPv4 space.
+    // A prefix that is not a plain non-negative integer must leave the entry
+    // inert. std::stoi() would read "-0" as 0 and the (bits < 0) guard cannot
+    // catch it, which would silently blacklist the entire IPv4 space.
     set_bl({"10.0.0.0/-0"});
-    XCHECK_EQ(bl("8.8.8.8"), false,
-              "blacklist_checker.cpp:57 stoi accepts \"-0\"; malformed prefix "
-              "degrades to /0 and matches every IPv4 address");
+    CHECK_EQ(bl("8.8.8.8"), false);
+    CHECK_EQ(bl("10.1.2.3"), false);
+    set_bl({"10.0.0.0/+8"});
+    CHECK_EQ(bl("8.8.8.8"), false);
+    set_bl({"10.0.0.0/ 8"});
+    CHECK_EQ(bl("10.1.2.3"), false);
+    set_bl({"10.0.0.0/-8"});
+    CHECK_EQ(bl("8.8.8.8"), false);
+    // Well-formed prefixes still work after the tightened validation.
+    set_bl({"10.0.0.0/08"});
+    CHECK_EQ(bl("10.1.2.3"), true);
 
     // ---------------------------------------------------------------- //
     SUITE("wildcard: leading '*' (suffix match)");
@@ -210,27 +220,38 @@ int main()
     CHECK_EQ(bl("10.1.2.3"), false); // "10.0.*.0" is not a valid base address
 
     // ---------------------------------------------------------------- //
-    SUITE("host comparison is case-sensitive");
+    SUITE("host comparison is case-insensitive (RFC 4343)");
     // ---------------------------------------------------------------- //
     // Hosts below contain an empty DNS label, so the resolver rejects them
     // locally and no query is ever emitted; the blacklist holds no IP-shaped
     // entries, so a resolver result could not change the answer either.
     set_bl({"CAM..BLOCKED"});
     CHECK_EQ(bl("CAM..BLOCKED"), true); // identical spelling matches
-    // DNS names are case-insensitive (RFC 4343), so an entry must block every
-    // case variant of the same name; today it does not, which is a blacklist
-    // bypass.
-    XCHECK(bl("cam..blocked"),
-           "blacklist_checker.cpp:26 exact match uses case-sensitive ==; "
-           "changing hostname case bypasses the blacklist");
-    XCHECK(bl("Cam..Blocked"),
-           "blacklist_checker.cpp:26 exact match is case-sensitive");
+    // DNS names are case-insensitive, so an entry blocks every case variant of
+    // the same name.
+    CHECK(bl("cam..blocked"));
+    CHECK(bl("Cam..Blocked"));
+    CHECK_EQ(bl("other..blocked"), false); // folding must not widen the match
+    // A lower-case entry blocks an upper-case host too.
+    set_bl({"cam..blocked"});
+    CHECK(bl("CAM..BLOCKED"));
 
     set_bl({"*.EVIL..BLOCKED"});
     CHECK_EQ(bl("host.EVIL..BLOCKED"), true);
-    XCHECK(bl("host.evil..blocked"),
-           "blacklist_checker.cpp:86 wildcard suffix compare is case-sensitive; "
-           "case variation bypasses *. patterns");
+    CHECK(bl("host.evil..blocked"));
+    CHECK(bl("HOST.Evil..Blocked"));
+    CHECK_EQ(bl("host.good..blocked"), false);
+
+    // Trailing '*' (prefix match) folds case as well.
+    set_bl({"CAM..EVIL*"});
+    CHECK(bl("cam..evil.example"));
+    CHECK(bl("CAM..EVIL"));
+    CHECK_EQ(bl("cam..good.example"), false);
+
+    // Case folding must not disturb numeric CIDR parsing.
+    set_bl({"10.0.0.0/8"});
+    CHECK_EQ(bl("10.1.2.3"), true);
+    CHECK_EQ(bl("11.1.2.3"), false);
 
     // ---------------------------------------------------------------- //
     SUITE("several patterns of mixed kinds in one blacklist");

--- a/test/unit/test_blacklist_checker.cpp
+++ b/test/unit/test_blacklist_checker.cpp
@@ -1,0 +1,266 @@
+// Unit tests for BlacklistChecker (src/utils/blacklist_checker.cpp).
+//
+// NOTE ON DNS: BlacklistChecker::is_blacklisted() falls through to
+// DNSResolver::resolve_ipv4() (a synchronous getaddrinfo) whenever the raw host
+// string does not match any blacklist entry. Every host used below is therefore
+// either
+//   * a literal dotted-quad IPv4 address  -> getaddrinfo parses it numerically,
+//     never touching the network, or
+//   * a syntactically invalid DNS name containing an empty label ("a..b")
+//     -> rejected by the resolver's name encoder before any query is sent.
+// For the invalid-name group the blacklist deliberately contains no IP-shaped
+// entries at all, so the outcome cannot depend on what any resolver returns.
+//
+// match_cidr()/match_wildcard() are private, so they are exercised through
+// is_blacklisted().
+
+#include "test_harness.h"
+
+#include "core/server_config.h"
+#include "utils/blacklist_checker.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+// ServerConfig is process-wide static state; every group sets it explicitly.
+void set_bl(std::initializer_list<const char *> entries)
+{
+    std::vector<std::string> v;
+    for (const char *e : entries)
+        v.emplace_back(e);
+    ServerConfig::setBlacklist(v);
+}
+
+bool bl(const char *host) { return BlacklistChecker::is_blacklisted(host); }
+
+} // namespace
+
+int main()
+{
+    // ---------------------------------------------------------------- //
+    SUITE("empty blacklist short-circuits to false");
+    // ---------------------------------------------------------------- //
+    set_bl({});
+    CHECK_EQ(bl("192.0.2.10"), false);
+    CHECK_EQ(bl("127.0.0.1"), false);
+    CHECK_EQ(bl("0.0.0.0"), false);
+    CHECK_EQ(bl("255.255.255.255"), false);
+    CHECK_EQ(bl(""), false);
+
+    // ---------------------------------------------------------------- //
+    SUITE("exact literal-IP entries");
+    // ---------------------------------------------------------------- //
+    set_bl({"192.0.2.10", "198.51.100.5"});
+    CHECK_EQ(bl("192.0.2.10"), true);
+    CHECK_EQ(bl("198.51.100.5"), true);
+    CHECK_EQ(bl("192.0.2.11"), false);
+    CHECK_EQ(bl("198.51.100.50"), false); // prefix of an entry is not a match
+    CHECK_EQ(bl("8.51.100.5"), false);    // suffix of an entry is not a match
+    CHECK_EQ(bl("192.0.2.1"), false);
+    // NOTE: a non-canonical spelling of a listed address ("192.0.2.010") is
+    // deliberately not asserted on. The string compare misses it, but the
+    // resolver pass then re-checks whatever getaddrinfo() canonicalises it to,
+    // and that differs between libcs (BSD reads "010" as decimal 10 and the
+    // entry matches; glibc's inet_aton reads it as octal 8 and it does not).
+
+    // ---------------------------------------------------------------- //
+    SUITE("CIDR /8");
+    // ---------------------------------------------------------------- //
+    set_bl({"10.0.0.0/8"});
+    CHECK_EQ(bl("10.0.0.0"), true);        // network address
+    CHECK_EQ(bl("10.1.2.3"), true);
+    CHECK_EQ(bl("10.255.255.255"), true);  // last address in range
+    CHECK_EQ(bl("9.255.255.255"), false);  // one below
+    CHECK_EQ(bl("11.0.0.0"), false);       // one above
+
+    // ---------------------------------------------------------------- //
+    SUITE("CIDR /12");
+    // ---------------------------------------------------------------- //
+    set_bl({"172.16.0.0/12"});
+    CHECK_EQ(bl("172.15.255.255"), false); // just outside, below
+    CHECK_EQ(bl("172.16.0.0"), true);      // first in range
+    CHECK_EQ(bl("172.20.30.40"), true);
+    CHECK_EQ(bl("172.31.255.255"), true);  // last in range
+    CHECK_EQ(bl("172.32.0.0"), false);     // just outside, above
+
+    // ---------------------------------------------------------------- //
+    SUITE("CIDR /16");
+    // ---------------------------------------------------------------- //
+    set_bl({"192.168.0.0/16"});
+    CHECK_EQ(bl("192.167.255.255"), false);
+    CHECK_EQ(bl("192.168.0.0"), true);
+    CHECK_EQ(bl("192.168.255.255"), true);
+    CHECK_EQ(bl("192.169.0.0"), false);
+
+    // ---------------------------------------------------------------- //
+    SUITE("CIDR /24");
+    // ---------------------------------------------------------------- //
+    set_bl({"198.51.100.0/24"});
+    CHECK_EQ(bl("198.51.99.255"), false);
+    CHECK_EQ(bl("198.51.100.0"), true);
+    CHECK_EQ(bl("198.51.100.255"), true);
+    CHECK_EQ(bl("198.51.101.0"), false);
+
+    // ---------------------------------------------------------------- //
+    SUITE("CIDR /32");
+    // ---------------------------------------------------------------- //
+    set_bl({"203.0.113.7/32"});
+    CHECK_EQ(bl("203.0.113.7"), true);
+    CHECK_EQ(bl("203.0.113.6"), false);
+    CHECK_EQ(bl("203.0.113.8"), false);
+
+    // ---------------------------------------------------------------- //
+    SUITE("CIDR /0 (must be well-defined, no shift-by-32 UB)");
+    // ---------------------------------------------------------------- //
+    set_bl({"0.0.0.0/0"});
+    CHECK_EQ(bl("0.0.0.0"), true);
+    CHECK_EQ(bl("8.8.8.8"), true);
+    CHECK_EQ(bl("255.255.255.255"), true);
+    // The base address is irrelevant once the prefix length is 0.
+    set_bl({"203.0.113.7/0"});
+    CHECK_EQ(bl("10.1.2.3"), true);
+
+    // ---------------------------------------------------------------- //
+    SUITE("CIDR misc: host bits in base, bad base, bad prefix");
+    // ---------------------------------------------------------------- //
+    // Host bits set in the base address are masked off, so the whole block
+    // still matches.
+    set_bl({"172.16.5.9/12"});
+    CHECK_EQ(bl("172.16.0.0"), true);
+    CHECK_EQ(bl("172.31.255.255"), true);
+    CHECK_EQ(bl("172.32.0.0"), false);
+
+    // Unparseable base address -> never matches (and must not crash).
+    set_bl({"999.0.0.0/8"});
+    CHECK_EQ(bl("10.1.2.3"), false);
+    CHECK_EQ(bl("192.0.2.10"), false);
+
+    // Prefix length out of range / not a number -> entry is inert.
+    set_bl({"10.0.0.0/33"});
+    CHECK_EQ(bl("10.1.2.3"), false);
+    set_bl({"10.0.0.0/-1"});
+    CHECK_EQ(bl("10.1.2.3"), false);
+    set_bl({"10.0.0.0/8x"});
+    CHECK_EQ(bl("10.1.2.3"), false);
+    set_bl({"10.0.0.0/"});
+    CHECK_EQ(bl("10.1.2.3"), false);
+    set_bl({"10.0.0.0/0x8"});
+    CHECK_EQ(bl("10.1.2.3"), false);
+
+    // BUG: std::stoi accepts "-0" as 0, and the (bits < 0) guard does not
+    // reject it, so a malformed prefix silently becomes /0 and blacklists the
+    // entire IPv4 space.
+    set_bl({"10.0.0.0/-0"});
+    XCHECK_EQ(bl("8.8.8.8"), false,
+              "blacklist_checker.cpp:57 stoi accepts \"-0\"; malformed prefix "
+              "degrades to /0 and matches every IPv4 address");
+
+    // ---------------------------------------------------------------- //
+    SUITE("wildcard: leading '*' (suffix match)");
+    // ---------------------------------------------------------------- //
+    set_bl({"*.2.10"});
+    CHECK_EQ(bl("192.0.2.10"), true);
+    CHECK_EQ(bl("198.51.2.10"), true);
+    CHECK_EQ(bl("192.0.2.11"), false);
+    CHECK_EQ(bl("192.0.12.10"), false); // the literal '.' before 2 must match
+    set_bl({"*192.0.2.10"});            // pattern longer than the host
+    CHECK_EQ(bl("0.2.10"), false);
+
+    // ---------------------------------------------------------------- //
+    SUITE("wildcard: trailing '*' (prefix match)");
+    // ---------------------------------------------------------------- //
+    set_bl({"192.0.*"});
+    CHECK_EQ(bl("192.0.2.10"), true);
+    CHECK_EQ(bl("192.0.113.9"), true);
+    CHECK_EQ(bl("192.1.2.10"), false);
+    CHECK_EQ(bl("10.192.0.1"), false); // prefix must be anchored at the start
+
+    // ---------------------------------------------------------------- //
+    SUITE("wildcard: bare '*' matches everything");
+    // ---------------------------------------------------------------- //
+    set_bl({"*"});
+    CHECK_EQ(bl("192.0.2.10"), true);
+    CHECK_EQ(bl("10.0.0.1"), true);
+
+    // ---------------------------------------------------------------- //
+    SUITE("wildcard: '*' in the middle is unsupported");
+    // ---------------------------------------------------------------- //
+    // Documented limitation: only a leading or trailing '*' is honoured. A '*'
+    // anywhere else falls through to a literal string comparison, which a real
+    // host can never satisfy, so nothing matches.
+    set_bl({"192.*.2.10"});
+    CHECK_EQ(bl("192.0.2.10"), false);
+    CHECK_EQ(bl("192.168.2.10"), false);
+    set_bl({"10.*.*.1"});
+    CHECK_EQ(bl("10.0.0.1"), false);
+
+    // ---------------------------------------------------------------- //
+    SUITE("pattern kind dispatch: '/' wins over '*'");
+    // ---------------------------------------------------------------- //
+    // A pattern containing a '/' is always treated as CIDR, even if it also
+    // contains a '*', so the '*' is never expanded.
+    set_bl({"10.0.*.0/8"});
+    CHECK_EQ(bl("10.1.2.3"), false); // "10.0.*.0" is not a valid base address
+
+    // ---------------------------------------------------------------- //
+    SUITE("host comparison is case-sensitive");
+    // ---------------------------------------------------------------- //
+    // Hosts below contain an empty DNS label, so the resolver rejects them
+    // locally and no query is ever emitted; the blacklist holds no IP-shaped
+    // entries, so a resolver result could not change the answer either.
+    set_bl({"CAM..BLOCKED"});
+    CHECK_EQ(bl("CAM..BLOCKED"), true); // identical spelling matches
+    // DNS names are case-insensitive (RFC 4343), so an entry must block every
+    // case variant of the same name; today it does not, which is a blacklist
+    // bypass.
+    XCHECK(bl("cam..blocked"),
+           "blacklist_checker.cpp:26 exact match uses case-sensitive ==; "
+           "changing hostname case bypasses the blacklist");
+    XCHECK(bl("Cam..Blocked"),
+           "blacklist_checker.cpp:26 exact match is case-sensitive");
+
+    set_bl({"*.EVIL..BLOCKED"});
+    CHECK_EQ(bl("host.EVIL..BLOCKED"), true);
+    XCHECK(bl("host.evil..blocked"),
+           "blacklist_checker.cpp:86 wildcard suffix compare is case-sensitive; "
+           "case variation bypasses *. patterns");
+
+    // ---------------------------------------------------------------- //
+    SUITE("several patterns of mixed kinds in one blacklist");
+    // ---------------------------------------------------------------- //
+    set_bl({"192.0.2.10", "10.0.0.0/8", "*.113.9", "172.16.*"});
+    CHECK_EQ(bl("192.0.2.10"), true);  // exact
+    CHECK_EQ(bl("10.9.9.9"), true);    // cidr
+    CHECK_EQ(bl("203.0.113.9"), true); // suffix wildcard
+    CHECK_EQ(bl("172.16.4.5"), true);  // prefix wildcard
+    CHECK_EQ(bl("198.51.100.5"), false);
+    CHECK_EQ(bl("11.9.9.9"), false);
+
+    // Re-running with an empty list must forget everything (no hidden state).
+    set_bl({});
+    CHECK_EQ(bl("10.9.9.9"), false);
+
+    // ---------------------------------------------------------------- //
+    SUITE("is_loopback with no usable socket fd");
+    // ---------------------------------------------------------------- //
+    // Only the non-socket paths are exercised here: getsockname() must fail and
+    // the function must report false rather than guessing.
+    CHECK_EQ(BlacklistChecker::is_loopback("127.0.0.1", 554, -1), false);
+    CHECK_EQ(BlacklistChecker::is_loopback("192.0.2.10", 8554, -1), false);
+    int devnull = ::open("/dev/null", O_RDONLY);
+    if (devnull >= 0)
+    {
+        // A valid fd that is not a socket -> ENOTSOCK -> false.
+        CHECK_EQ(BlacklistChecker::is_loopback("127.0.0.1", 554, devnull), false);
+        ::close(devnull);
+    }
+
+    return tst::summary();
+}

--- a/test/unit/test_harness.h
+++ b/test/unit/test_harness.h
@@ -1,0 +1,134 @@
+// Minimal dependency-free test harness.
+//
+// The project ships with no third-party runtime deps and cross-compiles against
+// musl / the OpenWrt SDK, so pulling in gtest or Catch2 via a meson subproject
+// would add a configure-time network fetch to every build. This header is the
+// whole framework instead.
+//
+// Usage:
+//     #include "test_harness.h"
+//     int main() {
+//         SUITE("url_rewriter");
+//         CHECK(cond);
+//         CHECK_EQ(actual, expected);
+//         XCHECK_EQ(actual, expected, "known bug: ...");  // reported, does not fail
+//         return tst::summary();
+//     }
+#pragma once
+
+#include <cstdio>
+#include <sstream>
+#include <string>
+
+namespace tst
+{
+
+inline int passed = 0;
+inline int failed = 0;
+inline int xfailed = 0;
+inline int xpassed = 0;
+
+inline void suite(const char *name)
+{
+    std::printf("=== %s ===\n", name);
+}
+
+template <typename T>
+inline std::string show(const T &v)
+{
+    std::ostringstream os;
+    os << v;
+    return os.str();
+}
+
+inline std::string show(bool v) { return v ? "true" : "false"; }
+inline std::string show(const std::string &v) { return "\"" + v + "\""; }
+inline std::string show(const char *v) { return std::string("\"") + v + "\""; }
+
+inline void report_pass(const char *expr)
+{
+    ++passed;
+    std::printf("  [ PASS ] %s\n", expr);
+}
+
+inline void report_fail(const char *expr, const char *file, int line,
+                        const std::string &detail)
+{
+    ++failed;
+    std::printf("  [ FAIL ] %s\n           at %s:%d\n", expr, file, line);
+    if (!detail.empty())
+        std::printf("%s\n", detail.c_str());
+}
+
+// A check that documents a bug which is known to be present and is not being
+// fixed in this change. It never fails the run, but an unexpected pass is
+// reported loudly so the marker gets removed once the bug is actually fixed.
+inline void report_xfail(const char *expr, const char *reason)
+{
+    ++xfailed;
+    std::printf("  [ XFAIL] %s\n           known bug: %s\n", expr, reason);
+}
+
+inline void report_xpass(const char *expr, const char *reason)
+{
+    ++xpassed;
+    std::printf("  [ XPASS] %s\n           expected to fail but passed -- drop the XCHECK: %s\n",
+                expr, reason);
+}
+
+inline int summary()
+{
+    std::printf("\n---- %d passed, %d failed, %d known-bug, %d unexpectedly-fixed ----\n",
+                passed, failed, xfailed, xpassed);
+    if (failed == 0)
+        std::printf("RESULT: OK\n");
+    else
+        std::printf("RESULT: FAILED\n");
+    return failed == 0 ? 0 : 1;
+}
+
+} // namespace tst
+
+#define SUITE(name) tst::suite(name)
+
+#define CHECK(cond)                                                            \
+    do                                                                         \
+    {                                                                          \
+        if (cond)                                                              \
+            tst::report_pass(#cond);                                           \
+        else                                                                   \
+            tst::report_fail(#cond, __FILE__, __LINE__, "");                   \
+    } while (0)
+
+#define CHECK_EQ(actual, expected)                                             \
+    do                                                                         \
+    {                                                                          \
+        auto _a = (actual);                                                    \
+        auto _e = (expected);                                                  \
+        if (_a == _e)                                                          \
+            tst::report_pass(#actual " == " #expected);                        \
+        else                                                                   \
+            tst::report_fail(#actual " == " #expected, __FILE__, __LINE__,     \
+                             "           expected: " + tst::show(_e) +         \
+                                 "\n           actual:   " + tst::show(_a));   \
+    } while (0)
+
+#define XCHECK(cond, reason)                                                   \
+    do                                                                         \
+    {                                                                          \
+        if (cond)                                                              \
+            tst::report_xpass(#cond, reason);                                  \
+        else                                                                   \
+            tst::report_xfail(#cond, reason);                                  \
+    } while (0)
+
+#define XCHECK_EQ(actual, expected, reason)                                    \
+    do                                                                         \
+    {                                                                          \
+        auto _a = (actual);                                                    \
+        auto _e = (expected);                                                  \
+        if (_a == _e)                                                          \
+            tst::report_xpass(#actual " == " #expected, reason);               \
+        else                                                                   \
+            tst::report_xfail(#actual " == " #expected, reason);               \
+    } while (0)

--- a/test/unit/test_port_pool.cpp
+++ b/test/unit/test_port_pool.cpp
@@ -1,0 +1,311 @@
+// Unit tests for PortPool (src/core/port_pool.cpp).
+//
+// PortPool is a process-wide singleton with a hard-coded range of
+// [start_port_ = 20000, end_port_ = 40000) and no reset entry point, so these
+// tests are written to be *self-cleaning*: every group releases everything it
+// acquired (including ports it marked occupied) before the next group runs.
+// The allocation cursor (next_port_) keeps moving forward regardless, so no
+// group asserts an absolute port number -- everything is expressed relative to
+// the first port that group acquired. The one exception is the final
+// exhaustion group, which deliberately drains the whole pool and therefore
+// runs last.
+//
+// PortPool reads no ServerConfig state (verified by reading the source: its
+// only external dependency is Logger), so there is no global config to pin.
+
+#include "test_harness.h"
+
+#include "core/logger.h"
+#include "core/port_pool.h"
+
+#include <set>
+#include <vector>
+
+static const uint16_t kStart = 20000; // PortPool::start_port_
+static const uint16_t kEnd = 40000;   // PortPool::end_port_ (exclusive)
+static const int kTotalPairs = (kEnd - kStart) / 2;
+
+static bool in_range(uint16_t p) { return p >= kStart && p < kEnd; }
+
+// ---------------------------------------------------------------------------
+
+static void test_acquire_shape(PortPool &pool)
+{
+    SUITE("acquire_pair: shape of a single allocation");
+
+    uint16_t p = pool.acquire_pair();
+
+    CHECK(p != 0);
+    CHECK_EQ(p % 2, 0);            // RTP port must be even (RFC 3550)
+    CHECK(in_range(p));            // inside the configured range
+    CHECK(in_range((uint16_t)(p + 1))); // ...and so is its RTCP successor
+    CHECK((uint16_t)(p + 1) < kEnd);
+
+    pool.release_pair(p);
+}
+
+static void test_pairs_never_overlap(PortPool &pool)
+{
+    SUITE("acquire_pair: repeated allocations never overlap");
+
+    const int kN = 32;
+    std::vector<uint16_t> bases;
+    std::set<uint16_t> reserved; // every port implied by a handed-out pair
+
+    bool all_even = true;
+    bool all_in_range = true;
+    bool all_disjoint = true;
+    bool none_zero = true;
+
+    for (int i = 0; i < kN; ++i)
+    {
+        uint16_t p = pool.acquire_pair();
+        if (p == 0)
+        {
+            none_zero = false;
+            break;
+        }
+        if (p % 2 != 0)
+            all_even = false;
+        if (!in_range(p) || !in_range((uint16_t)(p + 1)))
+            all_in_range = false;
+        // Neither the even port nor the odd successor may already be spoken for.
+        if (!reserved.insert(p).second)
+            all_disjoint = false;
+        if (!reserved.insert((uint16_t)(p + 1)).second)
+            all_disjoint = false;
+        bases.push_back(p);
+    }
+
+    CHECK(none_zero);
+    CHECK_EQ((int)bases.size(), kN);
+    CHECK(all_even);
+    CHECK(all_in_range);
+    CHECK(all_disjoint);
+    CHECK_EQ((int)reserved.size(), 2 * kN); // 2 ports burned per pair
+
+    // The cursor walks forward in steps of two, so an unfragmented pool hands
+    // out strictly increasing, adjacent pairs.
+    bool monotonic_by_two = true;
+    for (size_t i = 1; i < bases.size(); ++i)
+        if (bases[i] != (uint16_t)(bases[i - 1] + 2))
+            monotonic_by_two = false;
+    CHECK(monotonic_by_two);
+
+    // A base is always even, so an odd port can never be handed out as an RTP
+    // port; each odd port is only ever the reserved successor of its own pair.
+    bool no_odd_base = true;
+    for (uint16_t b : bases)
+        if (b % 2 != 0)
+            no_odd_base = false;
+    CHECK(no_odd_base);
+
+    for (uint16_t b : bases)
+        pool.release_pair(b);
+}
+
+static void test_cursor_does_not_reuse_immediately(PortPool &pool)
+{
+    SUITE("round-robin cursor: a just-released pair is not handed straight back");
+
+    uint16_t a = pool.acquire_pair();
+    CHECK(a != 0);
+    pool.release_pair(a);
+
+    uint16_t b = pool.acquire_pair();
+    CHECK(b != 0);
+    CHECK(b != a);                  // not immediately recycled
+    CHECK(b != (uint16_t)(a + 1));  // and never the odd half of anything
+    CHECK_EQ(b, a + 2);             // cursor advanced past the freed pair
+    CHECK_EQ(b % 2, 0);
+
+    // Same again: releasing does not rewind the cursor.
+    pool.release_pair(b);
+    uint16_t c = pool.acquire_pair();
+    CHECK(c != a);
+    CHECK(c != b);
+    CHECK_EQ(c, a + 4);
+
+    pool.release_pair(c);
+}
+
+static void test_mark_occupied_skips(PortPool &pool)
+{
+    SUITE("mark_occupied: an externally-bound port is skipped");
+
+    uint16_t x = pool.acquire_pair(); // cursor now points at x+2
+    CHECK(x != 0);
+
+    // Block the even (RTP) half of the pair the cursor is about to return.
+    pool.mark_occupied((uint16_t)(x + 2));
+    uint16_t y = pool.acquire_pair();
+    CHECK(y != 0);
+    CHECK(y != (uint16_t)(x + 2)); // the blocked pair was skipped
+    CHECK_EQ(y, x + 4);
+    CHECK_EQ(y % 2, 0);
+
+    // Block only the odd (RTCP) half of the *next* pair: the pair must still be
+    // skipped, because a usable pair needs both ports.
+    pool.mark_occupied((uint16_t)(x + 7)); // cursor is at x+6
+    uint16_t z = pool.acquire_pair();
+    CHECK(z != 0);
+    CHECK(z != (uint16_t)(x + 6)); // (x+6, x+7) unusable: odd half taken
+    CHECK_EQ(z, x + 8);
+
+    // Marking a port that is already in use is harmless and must not corrupt
+    // the pair that owns it.
+    pool.mark_occupied(z);
+    pool.mark_occupied((uint16_t)(z + 1));
+    uint16_t w = pool.acquire_pair();
+    CHECK(w != 0);
+    CHECK(w != z);
+    CHECK_EQ(w, x + 10);
+
+    // Clean up: release the acquired pairs and clear the occupancy marks so the
+    // exhaustion group below still sees a pristine range.
+    pool.release_pair(x);
+    pool.release_pair(y);
+    pool.release_pair(z);
+    pool.release_pair(w);
+    pool.release_pair((uint16_t)(x + 2)); // clears the mark on x+2
+    pool.release_pair((uint16_t)(x + 6)); // clears the mark on x+7
+}
+
+static void test_release_edge_cases(PortPool &pool)
+{
+    SUITE("release_pair: guarded and idempotent for the simple cases");
+
+    pool.release_pair(0); // explicitly guarded no-op
+
+    uint16_t c = pool.acquire_pair();
+    CHECK(c != 0);
+    pool.release_pair(c);
+    pool.release_pair(c); // double release must not throw or corrupt the set
+
+    uint16_t d = pool.acquire_pair();
+    CHECK(d != 0);
+    CHECK_EQ(d, c + 2);
+    pool.release_pair(d);
+
+    // Releasing a pair that was never acquired is a no-op for the allocator.
+    pool.release_pair((uint16_t)(kEnd - 10));
+    uint16_t e = pool.acquire_pair();
+    CHECK(e != 0);
+    CHECK_EQ(e, d + 2);
+    pool.release_pair(e);
+}
+
+static void test_exhaustion_reuse_and_odd_release(PortPool &pool)
+{
+    SUITE("exhaustion, reuse after release, and the odd-port release bug");
+
+    // --- drain the pool -----------------------------------------------------
+    std::vector<uint16_t> bases;
+    std::set<uint16_t> seen;
+    bool all_even = true;
+    bool all_in_range = true;
+    bool all_unique = true;
+
+    for (;;)
+    {
+        uint16_t p = pool.acquire_pair();
+        if (p == 0)
+            break;
+        if (p % 2 != 0)
+            all_even = false;
+        if (!in_range(p))
+            all_in_range = false;
+        if (!seen.insert(p).second)
+            all_unique = false;
+        bases.push_back(p);
+        if ((int)bases.size() > kTotalPairs) // runaway guard
+            break;
+    }
+
+    CHECK(all_even);
+    CHECK(all_in_range);
+    CHECK(all_unique);
+    // Exactly (end - start) / 2 pairs fit, which is only true if every
+    // allocation reserves both the even port and its odd successor.
+    CHECK_EQ((int)bases.size(), kTotalPairs);
+    CHECK_EQ((int)seen.size(), kTotalPairs);
+    CHECK_EQ(*seen.begin(), kStart);
+    CHECK_EQ(*seen.rbegin(), (uint16_t)(kEnd - 2));
+
+    // The range top is respected: kEnd-1 is used only as an RTCP successor and
+    // kEnd itself is never touched.
+    CHECK(seen.find((uint16_t)(kEnd - 1)) == seen.end());
+
+    // --- exhaustion ---------------------------------------------------------
+    CHECK_EQ(pool.acquire_pair(), 0); // no pair left
+    CHECK_EQ(pool.acquire_pair(), 0); // and it stays that way
+
+    // --- release makes a pair reusable --------------------------------------
+    const uint16_t kVictim = 30000; // even, inside the range, currently held
+    pool.release_pair(kVictim);
+    uint16_t reused = pool.acquire_pair();
+    CHECK(reused != 0);
+    CHECK_EQ(reused, kVictim); // the only free pair must be handed back
+    CHECK_EQ(pool.acquire_pair(), 0);
+
+    // --- release_pair() validates neither evenness nor ownership -------------
+    // The pool is full again. Pairs (30000,30001) and (30002,30003) are both
+    // live and owned by different (hypothetical) sessions. A caller that passes
+    // the RTCP port instead of the RTP port frees one half of *each* of two
+    // different pairs.
+    pool.release_pair((uint16_t)(kVictim + 1)); // odd: erases 30001 and 30002
+
+    // Correct so far only by accident: no *complete* pair is free yet.
+    CHECK_EQ(pool.acquire_pair(), 0);
+
+    // A second caller makes the same mistake one pair along.
+    pool.release_pair((uint16_t)(kVictim + 3)); // odd: erases 30003 and 30004
+
+    // Ports 30002/30003 have now been freed by two callers, neither of which
+    // owned that pair -- its real owner has never released it.
+    uint16_t doubled = pool.acquire_pair();
+    XCHECK(doubled != (uint16_t)(kVictim + 2),
+           "release_pair() ignores evenness/ownership: an odd port frees half of "
+           "two pairs, so a live pair (30002/30003) gets handed out twice");
+    XCHECK_EQ(doubled, 0,
+              "no pair was legitimately released, so acquire_pair() should still "
+              "report exhaustion instead of double-allocating");
+
+    // Whatever came back must at least still look like a valid RTP port.
+    CHECK(doubled == 0 || doubled % 2 == 0);
+    CHECK(doubled == 0 || in_range(doubled));
+
+    // The pair whose even half was stolen (30000/30001) is now half-leaked: its
+    // even port is still marked used, so it can never be handed out again until
+    // its owner releases it properly. A correct release must restore it.
+    pool.release_pair(kVictim);
+    if (doubled != 0)
+        pool.release_pair(doubled);
+    uint16_t after = pool.acquire_pair();
+    CHECK(after != 0);
+    CHECK_EQ(after % 2, 0);
+    CHECK(in_range(after));
+
+    // Give everything back so the process ends with a clean pool.
+    if (after != 0)
+        pool.release_pair(after);
+    for (uint16_t b : bases)
+        pool.release_pair(b);
+}
+
+int main()
+{
+    // Keep the pool's exhaustion log lines out of the way where possible.
+    Logger::setLogLevel(LogLevel::ERROR);
+
+    PortPool &pool = PortPool::getInstance();
+
+    test_acquire_shape(pool);
+    test_pairs_never_overlap(pool);
+    test_cursor_does_not_reuse_immediately(pool);
+    test_mark_occupied_skips(pool);
+    test_release_edge_cases(pool);
+    test_exhaustion_reuse_and_odd_release(pool); // must run last: drains the pool
+
+    return tst::summary();
+}

--- a/test/unit/test_port_pool.cpp
+++ b/test/unit/test_port_pool.cpp
@@ -9,9 +9,11 @@
 // the first port that group acquired. The one exception is the exhaustion
 // group, which deliberately drains the whole pool.
 //
-// mark_occupied() has no expiry and no un-mark entry point, so the group that
-// exercises it cannot clean up after itself and runs last, after the group that
-// needs an undamaged range.
+// mark_occupied() has a 5-minute expiry and no un-mark entry point, so within a
+// test run its marks are effectively permanent: the groups that place them
+// cannot clean up after themselves and run last, after the groups that need an
+// undamaged range. The expiry itself is not exercised here -- it would mean
+// waiting out the TTL or adding a test-only seam to the singleton.
 //
 // PortPool reads no ServerConfig state (verified by reading the source: its
 // only external dependency is Logger), so there is no global config to pin.
@@ -21,6 +23,7 @@
 #include "core/logger.h"
 #include "core/port_pool.h"
 
+#include <algorithm>
 #include <set>
 #include <vector>
 
@@ -307,6 +310,75 @@ static void test_exhaustion_reuse_and_odd_release(PortPool &pool)
         pool.release_pair(b);
 }
 
+// ---------------------------------------------------------------------------
+
+// bind_udp_pair_from_pool() hands the pair back and *then* blocks the half that
+// some other process holds:
+//
+//     pool.release_pair(rtp_port);        // the pool is no longer the owner
+//     pool.mark_occupied(rtp_port + 1);   // ...but this half is really taken
+//
+// release_pair() drops both halves out of used_ports_, so unless it re-asserts
+// any live mark the block evaporates and the pool hands a port that a foreign
+// process is sitting on to the next session -- which then fails to bind too.
+// Both orderings are checked because callers are free to use either.
+static void test_release_preserves_occupied_mark(PortPool &pool)
+{
+    SUITE("release_pair: giving a pair back does not clear a foreign-held mark");
+
+    // release, then mark -- the order bind_udp_pair_from_pool() uses.
+    uint16_t a = pool.acquire_pair();
+    CHECK(a != 0);
+    pool.release_pair(a);
+    pool.mark_occupied((uint16_t)(a + 1));
+
+    // mark, then release -- the same invariant from the other direction.
+    uint16_t b = pool.acquire_pair();
+    CHECK(b != 0);
+    CHECK(b != a);
+    pool.mark_occupied((uint16_t)(b + 1));
+    pool.release_pair(b);
+
+    // A pair with no mark at all, released the same way, must come back.
+    uint16_t c = pool.acquire_pair();
+    CHECK(c != 0);
+    CHECK(c != a);
+    CHECK(c != b);
+    pool.release_pair(c);
+
+    // Walk the whole range. Every pair the pool still considers usable comes
+    // out exactly once, so the set difference says precisely which pairs are
+    // blocked -- no reliance on where the round-robin cursor happens to sit.
+    std::vector<uint16_t> handed_out;
+    while (true)
+    {
+        uint16_t p = pool.acquire_pair();
+        if (p == 0)
+            break;
+        handed_out.push_back(p);
+    }
+
+    auto was_handed_out = [&](uint16_t p) {
+        return std::find(handed_out.begin(), handed_out.end(), p) != handed_out.end();
+    };
+
+    CHECK(!was_handed_out(a)); // odd half marked after the release
+    CHECK(!was_handed_out(b)); // odd half marked before the release
+    CHECK(was_handed_out(c));  // unmarked: a plain release returns the pair
+
+    // No duplicates: a pair must never be handed to two sessions at once.
+    std::set<uint16_t> unique(handed_out.begin(), handed_out.end());
+    CHECK_EQ((int)unique.size(), (int)handed_out.size());
+
+    // Exactly the two marked pairs are missing from an otherwise intact range
+    // -- the marks placed by the earlier group are still in effect, so this is
+    // a relative count.
+    CHECK(handed_out.size() > 0);
+
+    for (uint16_t p : handed_out)
+        pool.release_pair(p);
+}
+
 int main()
 {
     // Keep the pool's exhaustion log lines out of the way where possible.
@@ -320,6 +392,7 @@ int main()
     test_release_edge_cases(pool);
     test_exhaustion_reuse_and_odd_release(pool); // drains the pool, then restores it
     test_mark_occupied_skips(pool); // must run last: its marks are permanent
+    test_release_preserves_occupied_mark(pool); // ...and so are this one's
 
     return tst::summary();
 }

--- a/test/unit/test_port_pool.cpp
+++ b/test/unit/test_port_pool.cpp
@@ -2,13 +2,16 @@
 //
 // PortPool is a process-wide singleton with a hard-coded range of
 // [start_port_ = 20000, end_port_ = 40000) and no reset entry point, so these
-// tests are written to be *self-cleaning*: every group releases everything it
-// acquired (including ports it marked occupied) before the next group runs.
+// tests are written to be *self-cleaning*: every group releases every pair it
+// acquired before the next group runs.
 // The allocation cursor (next_port_) keeps moving forward regardless, so no
 // group asserts an absolute port number -- everything is expressed relative to
-// the first port that group acquired. The one exception is the final
-// exhaustion group, which deliberately drains the whole pool and therefore
-// runs last.
+// the first port that group acquired. The one exception is the exhaustion
+// group, which deliberately drains the whole pool.
+//
+// mark_occupied() has no expiry and no un-mark entry point, so the group that
+// exercises it cannot clean up after itself and runs last, after the group that
+// needs an undamaged range.
 //
 // PortPool reads no ServerConfig state (verified by reading the source: its
 // only external dependency is Logger), so there is no global config to pin.
@@ -161,14 +164,13 @@ static void test_mark_occupied_skips(PortPool &pool)
     CHECK(w != z);
     CHECK_EQ(w, x + 10);
 
-    // Clean up: release the acquired pairs and clear the occupancy marks so the
-    // exhaustion group below still sees a pristine range.
+    // Clean up the acquired pairs. The occupancy marks on x+2 and x+7 cannot be
+    // cleared -- release_pair() only accepts pairs handed out by acquire_pair(),
+    // and mark_occupied() has no expiry -- which is why this group runs last.
     pool.release_pair(x);
     pool.release_pair(y);
     pool.release_pair(z);
     pool.release_pair(w);
-    pool.release_pair((uint16_t)(x + 2)); // clears the mark on x+2
-    pool.release_pair((uint16_t)(x + 6)); // clears the mark on x+7
 }
 
 static void test_release_edge_cases(PortPool &pool)
@@ -193,6 +195,22 @@ static void test_release_edge_cases(PortPool &pool)
     CHECK(e != 0);
     CHECK_EQ(e, d + 2);
     pool.release_pair(e);
+
+    // The odd (RTCP) half of a live pair is never a valid release target, and
+    // rejecting it must leave the pair's ownership intact so that its real owner
+    // can still release it afterwards.
+    uint16_t f = pool.acquire_pair();
+    CHECK(f != 0);
+    CHECK_EQ(f, e + 2);
+    pool.release_pair((uint16_t)(f + 1)); // odd: rejected
+    pool.release_pair(f);                 // still owned, so this works
+    pool.release_pair(f);                 // no longer owned: no-op
+
+    uint16_t g = pool.acquire_pair();
+    CHECK(g != 0);
+    CHECK_EQ(g, f + 2);
+    CHECK_EQ(g % 2, 0);
+    pool.release_pair(g);
 }
 
 static void test_exhaustion_reuse_and_odd_release(PortPool &pool)
@@ -248,36 +266,32 @@ static void test_exhaustion_reuse_and_odd_release(PortPool &pool)
     CHECK_EQ(reused, kVictim); // the only free pair must be handed back
     CHECK_EQ(pool.acquire_pair(), 0);
 
-    // --- release_pair() validates neither evenness nor ownership -------------
+    // --- release_pair() validates evenness and ownership ---------------------
     // The pool is full again. Pairs (30000,30001) and (30002,30003) are both
     // live and owned by different (hypothetical) sessions. A caller that passes
-    // the RTCP port instead of the RTP port frees one half of *each* of two
-    // different pairs.
-    pool.release_pair((uint16_t)(kVictim + 1)); // odd: erases 30001 and 30002
+    // the RTCP port instead of the RTP port must not free one half of *each* of
+    // two different pairs.
+    pool.release_pair((uint16_t)(kVictim + 1)); // odd: rejected
 
-    // Correct so far only by accident: no *complete* pair is free yet.
     CHECK_EQ(pool.acquire_pair(), 0);
 
     // A second caller makes the same mistake one pair along.
-    pool.release_pair((uint16_t)(kVictim + 3)); // odd: erases 30003 and 30004
+    pool.release_pair((uint16_t)(kVictim + 3)); // odd: rejected
 
-    // Ports 30002/30003 have now been freed by two callers, neither of which
-    // owned that pair -- its real owner has never released it.
+    // Neither caller owned (30002,30003), and its real owner has never released
+    // it, so it must not be handed to a second session.
     uint16_t doubled = pool.acquire_pair();
-    XCHECK(doubled != (uint16_t)(kVictim + 2),
-           "release_pair() ignores evenness/ownership: an odd port frees half of "
-           "two pairs, so a live pair (30002/30003) gets handed out twice");
-    XCHECK_EQ(doubled, 0,
-              "no pair was legitimately released, so acquire_pair() should still "
-              "report exhaustion instead of double-allocating");
+    CHECK(doubled != (uint16_t)(kVictim + 2));
+    CHECK_EQ(doubled, 0);
 
     // Whatever came back must at least still look like a valid RTP port.
     CHECK(doubled == 0 || doubled % 2 == 0);
     CHECK(doubled == 0 || in_range(doubled));
 
-    // The pair whose even half was stolen (30000/30001) is now half-leaked: its
-    // even port is still marked used, so it can never be handed out again until
-    // its owner releases it properly. A correct release must restore it.
+    // A rejected release must not half-leak the pair it was called on either:
+    // (30000,30001) is still intact, so its owner gets the whole pair back.
+    pool.release_pair(kVictim);
+    CHECK_EQ(pool.acquire_pair(), kVictim);
     pool.release_pair(kVictim);
     if (doubled != 0)
         pool.release_pair(doubled);
@@ -303,9 +317,9 @@ int main()
     test_acquire_shape(pool);
     test_pairs_never_overlap(pool);
     test_cursor_does_not_reuse_immediately(pool);
-    test_mark_occupied_skips(pool);
     test_release_edge_cases(pool);
-    test_exhaustion_reuse_and_odd_release(pool); // must run last: drains the pool
+    test_exhaustion_reuse_and_odd_release(pool); // drains the pool, then restores it
+    test_mark_occupied_skips(pool); // must run last: its marks are permanent
 
     return tst::summary();
 }

--- a/test/unit/test_request_parser.cpp
+++ b/test/unit/test_request_parser.cpp
@@ -126,14 +126,20 @@ int main()
                     tst::show(i.method).c_str(), tst::show(i.raw_uri).c_str());
     }
     {
-        // ...and the early return happens *before* sanitize_input(), so on the
-        // failure path raw bytes reach the caller (and its log line) unescaped.
+        // ...and the early return still sanitizes what the extraction managed to
+        // write, so no raw byte reaches the caller (and its log line).
         RequestInfo i = P("GET /a\x1b[31mBOOM");
-        XCHECK_EQ(first_raw_byte(i.raw_uri, '\x1b'), NPOS_OK,
-                  "the early return for a short request line skips sanitize_input(), "
-                  "so a raw ESC survives in raw_uri -- terminal injection via logs");
-        XCHECK_EQ(first_raw_byte(P("GET /a\\b").raw_uri, '\\'), NPOS_OK,
-                  "backslash stripping is also skipped on the early-return path");
+        CHECK_EQ(first_raw_byte(i.raw_uri, '\x1b'), NPOS_OK);
+        CHECK_EQ(i.raw_uri, "/a\\x1b[31mBOOM");
+        CHECK_EQ(first_raw_byte(P("GET /a\\b").raw_uri, '\\'), NPOS_OK);
+        CHECK_EQ(P("GET /a\\b").raw_uri, "/ab");
+        // The method token is escaped on this path as well.
+        CHECK_EQ(P("\x1bGET /a").method, "\\x1bGET");
+        // %5C removal happens here too, and the early return is still taken.
+        RequestInfo j = P("GET /rtp%5C/192.0.2.10:5540/live");
+        CHECK_EQ(j.raw_uri, "/rtp/192.0.2.10:5540/live");
+        CHECK_EQ(j.upstream_url, "");
+        CHECK_EQ(j.clean_uri, "");
     }
     {
         // Leading whitespace is skipped by the stream extraction.
@@ -383,39 +389,44 @@ int main()
     }
 
     // ------------------------------------------------------------------
-    SUITE("upstream_url: unanchored prefix search");
+    SUITE("upstream_url: prefix is anchored at the start of the path");
     // ------------------------------------------------------------------
     ServerConfig::setToken("");
     {
-        // find("/rtp/") is not anchored to the start of the path, so "/rtp/"
-        // appearing anywhere -- here only inside a query parameter value on an
-        // unrelated endpoint -- is enough to make the parser build an upstream
-        // URL out of it. An attacker-supplied query parameter therefore picks
-        // the upstream host: this should be a prefix test on the path.
+        // "/rtp/" inside a query parameter value on an unrelated endpoint must
+        // not select the upstream host, and the query itself is left alone.
         RequestInfo i = P("GET /index?x=/rtp/192.0.2.1:554/s HTTP/1.1");
         CHECK_EQ(i.clean_uri, "/index?x=/rtp/192.0.2.1:554/s");
-        std::printf("  [ NOTE ] /index?x=/rtp/... yields upstream_url = %s\n",
-                    tst::show(i.upstream_url).c_str());
-        XCHECK_EQ(i.upstream_url, "",
-                  "unanchored find(\"/rtp/\"): a /rtp/ inside the query string of an "
-                  "unrelated path still sets upstream_url (attacker picks the upstream)");
+        CHECK_EQ(i.upstream_url, "");
     }
     {
-        // Same defect via a path that merely contains the prefix deeper down.
-        RequestInfo i = P("GET /static/rtp/192.0.2.1:554/s HTTP/1.1");
-        XCHECK_EQ(i.upstream_url, "",
-                  "unanchored find(\"/rtp/\"): /static/rtp/... is not a stream path but "
-                  "still resolves to an upstream");
+        // A path that merely contains the prefix deeper down is not a stream.
+        CHECK_EQ(P("GET /static/rtp/192.0.2.1:554/s HTTP/1.1").upstream_url, "");
+        CHECK_EQ(P("GET /a/tv/192.0.2.1:554/s HTTP/1.1").upstream_url, "");
     }
     {
-        // /rtp/ is searched before /tv/, so on a genuine /tv/ path that happens
-        // to contain "/rtp/" later the wrong (and much shorter) sub-path wins.
+        // A genuine /tv/ path that happens to contain "/rtp/" further along is
+        // no longer truncated to the /rtp/ suffix.
         RequestInfo i = P("GET /tv/192.0.2.20:554/a/rtp/x HTTP/1.1");
-        std::printf("  [ NOTE ] /tv/...a/rtp/x yields upstream_url = %s\n",
-                    tst::show(i.upstream_url).c_str());
-        XCHECK_EQ(i.upstream_url, "rtsp://192.0.2.20:554/a/rtp/x",
-                  "the /rtp/ search runs first and is unanchored, so a /tv/ path "
-                  "containing /rtp/ is truncated to the /rtp/ suffix");
+        CHECK_EQ(i.upstream_url, "rtsp://192.0.2.20:554/a/rtp/x");
+    }
+    {
+        // An absolute URI keeps working: RTSP clients send one on every request
+        // after the redirect, so the scheme and authority are skipped.
+        CHECK_EQ(P("DESCRIBE rtsp://192.0.2.9:8554/rtp/192.0.2.10:5540/live RTSP/1.0").upstream_url,
+                 "rtsp://192.0.2.10:5540/live");
+        CHECK_EQ(P("PLAY rtsp://192.0.2.9:8554/tv/192.0.2.20:554/ch?a=1 RTSP/1.0").upstream_url,
+                 "rtsp://192.0.2.20:554/ch?a=1");
+        // ...but only when the prefix really starts the path.
+        CHECK_EQ(P("DESCRIBE rtsp://192.0.2.9:8554/x/rtp/192.0.2.10:5540/live RTSP/1.0").upstream_url,
+                 "");
+        // An authority with no path at all must not be mistaken for one.
+        CHECK_EQ(P("OPTIONS rtsp://192.0.2.9:8554 RTSP/1.0").upstream_url, "");
+    }
+    {
+        // A "://" that only appears inside the query string must not be taken
+        // for a scheme separator and move the anchor into the query.
+        CHECK_EQ(P("GET /index?u=http://h/rtp/192.0.2.1:554/s HTTP/1.1").upstream_url, "");
     }
 
     ServerConfig::setToken("");

--- a/test/unit/test_request_parser.cpp
+++ b/test/unit/test_request_parser.cpp
@@ -1,0 +1,423 @@
+// Unit tests for RequestParser (src/protocol/request_parser.cpp).
+//
+// RequestParser::parse() is the very first thing that touches attacker
+// controlled bytes: it splits the request line, sanitizes it for logging,
+// strips backslash escapes, extracts query parameters, checks the auth token
+// and derives the upstream RTSP URL. Everything here is pure string handling,
+// so no sockets and no DNS are involved -- upstream hosts are always written
+// as literal dotted-quad addresses so that nothing can ever try to resolve.
+//
+// Build and run:
+//   meson setup build -Dtests=true && meson test -C build request_parser
+
+#include "test_harness.h"
+
+#include "protocol/request_parser.h"
+#include "core/server_config.h"
+
+#include <string>
+
+namespace
+{
+
+RequestInfo P(const std::string &request_line)
+{
+    return RequestParser::parse(request_line);
+}
+
+// Convenience: value of a query parameter, or a sentinel when absent.
+std::string param(const RequestInfo &info, const std::string &key)
+{
+    auto it = info.params.find(key);
+    return it == info.params.end() ? std::string("<absent>") : it->second;
+}
+
+bool has_param(const RequestInfo &info, const std::string &key)
+{
+    return info.params.find(key) != info.params.end();
+}
+
+const std::string NPOS_OK = "<none>";
+
+// Returns NPOS_OK when the byte is absent, otherwise a description, so a
+// failure message shows which byte leaked instead of just "false".
+std::string first_raw_byte(const std::string &s, char needle)
+{
+    size_t p = s.find(needle);
+    if (p == std::string::npos)
+        return NPOS_OK;
+    return "raw byte at offset " + std::to_string(p);
+}
+
+} // namespace
+
+int main()
+{
+    // ------------------------------------------------------------------
+    SUITE("request line: HTTP");
+    // ------------------------------------------------------------------
+    ServerConfig::setToken("");
+    {
+        RequestInfo i = P("GET /rtp/192.0.2.10:5540/live HTTP/1.1\r\n");
+        CHECK_EQ(i.method, "GET");
+        CHECK_EQ(i.raw_uri, "/rtp/192.0.2.10:5540/live");
+        CHECK_EQ(i.version, "HTTP/1.1");
+        CHECK_EQ(i.is_http, true);
+        // The CRLF terminator must never end up inside a parsed field.
+        CHECK_EQ(first_raw_byte(i.version, '\r'), NPOS_OK);
+        CHECK_EQ(first_raw_byte(i.version, '\n'), NPOS_OK);
+    }
+    {
+        // Headers following the request line are ignored, and extra tokens on
+        // the request line itself are dropped rather than merged into version.
+        RequestInfo i = P("GET /status HTTP/1.0 junk\r\nHost: 192.0.2.10\r\n\r\n");
+        CHECK_EQ(i.method, "GET");
+        CHECK_EQ(i.raw_uri, "/status");
+        CHECK_EQ(i.version, "HTTP/1.0");
+        CHECK_EQ(i.is_http, true);
+    }
+
+    // ------------------------------------------------------------------
+    SUITE("request line: RTSP");
+    // ------------------------------------------------------------------
+    {
+        RequestInfo i = P("OPTIONS rtsp://192.0.2.10:554/live RTSP/1.0\r\n");
+        CHECK_EQ(i.method, "OPTIONS");
+        CHECK_EQ(i.raw_uri, "rtsp://192.0.2.10:554/live");
+        CHECK_EQ(i.version, "RTSP/1.0");
+        CHECK_EQ(i.is_http, false);
+    }
+    {
+        RequestInfo i = P("DESCRIBE /rtp/192.0.2.10:5540/live RTSP/1.0\r\n");
+        CHECK_EQ(i.is_http, false);
+        CHECK_EQ(i.upstream_url, "rtsp://192.0.2.10:5540/live");
+    }
+    {
+        // is_http is a prefix test on the version token, so anything that is
+        // not literally "HTTP/..." is treated as RTSP.
+        CHECK_EQ(P("GET /x SIP/2.0").is_http, false);
+        CHECK_EQ(P("GET /x XHTTP/1.1").is_http, false);
+    }
+
+    // ------------------------------------------------------------------
+    SUITE("request line: malformed input");
+    // ------------------------------------------------------------------
+    {
+        RequestInfo i = P("");
+        CHECK_EQ(i.method, "");
+        CHECK_EQ(i.raw_uri, "");
+        CHECK_EQ(i.version, "");
+        CHECK_EQ(i.upstream_url, "");
+        // Bailing out early must never hand back an authorized request.
+        CHECK_EQ(i.is_authorized, false);
+    }
+    {
+        // Only two tokens -> the chained extraction fails on the version, so
+        // parse() bails out early. Nothing downstream may be derived from it.
+        RequestInfo i = P("GET /rtp/192.0.2.10:554/live");
+        CHECK_EQ(i.version, "");
+        CHECK_EQ(i.upstream_url, "");
+        CHECK_EQ(i.is_authorized, false);
+        CHECK_EQ(i.clean_uri, "");
+        CHECK_EQ(i.params.empty(), true);
+        // The first two tokens were already written by the chained >> before it
+        // failed, so they survive the early return.
+        std::printf("  [ NOTE ] truncated request line leaves method=%s raw_uri=%s\n",
+                    tst::show(i.method).c_str(), tst::show(i.raw_uri).c_str());
+    }
+    {
+        // ...and the early return happens *before* sanitize_input(), so on the
+        // failure path raw bytes reach the caller (and its log line) unescaped.
+        RequestInfo i = P("GET /a\x1b[31mBOOM");
+        XCHECK_EQ(first_raw_byte(i.raw_uri, '\x1b'), NPOS_OK,
+                  "the early return for a short request line skips sanitize_input(), "
+                  "so a raw ESC survives in raw_uri -- terminal injection via logs");
+        XCHECK_EQ(first_raw_byte(P("GET /a\\b").raw_uri, '\\'), NPOS_OK,
+                  "backslash stripping is also skipped on the early-return path");
+    }
+    {
+        // Leading whitespace is skipped by the stream extraction.
+        RequestInfo i = P("   GET   /status   HTTP/1.1");
+        CHECK_EQ(i.method, "GET");
+        CHECK_EQ(i.raw_uri, "/status");
+        CHECK_EQ(i.version, "HTTP/1.1");
+    }
+
+    // ------------------------------------------------------------------
+    SUITE("sanitize_input: control bytes cannot reach the log");
+    // ------------------------------------------------------------------
+    {
+        // ESC is the terminal-injection primitive: a raw 0x1b in the URI would
+        // let a request repaint the operator's terminal via the log line.
+        RequestInfo i = P("GET /a\x1b[31mBOOM HTTP/1.1");
+        CHECK_EQ(i.raw_uri, "/a\\x1b[31mBOOM");
+        CHECK_EQ(first_raw_byte(i.raw_uri, '\x1b'), NPOS_OK);
+    }
+    {
+        // Same treatment for the method and version tokens.
+        RequestInfo i = P("\x1bG\aET /x \x1bHTTP/1.1"); // \a == BEL == 0x07
+        CHECK_EQ(i.method, "\\x1bG\\x07ET");
+        CHECK_EQ(first_raw_byte(i.method, '\x1b'), NPOS_OK);
+        CHECK_EQ(i.version, "\\x1bHTTP/1.1");
+        // The escaped version no longer starts with "HTTP/", so it is not HTTP.
+        CHECK_EQ(i.is_http, false);
+    }
+    {
+        // A NUL byte inside the URI is not whitespace, so it stays in the token
+        // and must come out escaped rather than truncating the string.
+        std::string uri = std::string("/a") + '\0' + "b";
+        RequestInfo i = P("GET " + uri + " HTTP/1.1");
+        CHECK_EQ(i.raw_uri, "/a\\x00b");
+    }
+    {
+        // DEL (0x7f) is above the printable range and must be escaped too;
+        // 0x20 (space) and 0x7e (~) are the inclusive boundaries that stay.
+        RequestInfo i = P("GET /a\x7f~ HTTP/1.1");
+        CHECK_EQ(i.raw_uri, "/a\\x7f~");
+    }
+    {
+        // A bare CR inside the URI is whitespace to the extractor, so it splits
+        // the token -- what matters is that no raw CR survives anywhere.
+        RequestInfo i = P("GET /a\rInjected: x HTTP/1.1");
+        CHECK_EQ(first_raw_byte(i.method, '\r'), NPOS_OK);
+        CHECK_EQ(first_raw_byte(i.raw_uri, '\r'), NPOS_OK);
+        CHECK_EQ(first_raw_byte(i.version, '\r'), NPOS_OK);
+        CHECK_EQ(i.raw_uri, "/a");
+    }
+    {
+        // High-bit / UTF-8 bytes are escaped byte by byte.
+        RequestInfo i = P("GET /\xc3\xa9 HTTP/1.1");
+        CHECK_EQ(i.raw_uri, "/\\xc3\\xa9");
+    }
+
+    // ------------------------------------------------------------------
+    SUITE("URI cleanup: backslash and %5C stripping");
+    // ------------------------------------------------------------------
+    {
+        RequestInfo i = P("GET /rtp\\/192.0.2.10:5540/live HTTP/1.1");
+        CHECK_EQ(i.raw_uri, "/rtp/192.0.2.10:5540/live");
+        CHECK_EQ(i.upstream_url, "rtsp://192.0.2.10:5540/live");
+    }
+    {
+        RequestInfo i = P("GET /rtp%5C/192.0.2.10:5540/live HTTP/1.1");
+        CHECK_EQ(i.raw_uri, "/rtp/192.0.2.10:5540/live");
+        CHECK_EQ(i.upstream_url, "rtsp://192.0.2.10:5540/live");
+    }
+    {
+        // Lowercase percent-escape is handled as well.
+        RequestInfo i = P("GET /rtp%5c/192.0.2.10:5540/live HTTP/1.1");
+        CHECK_EQ(i.raw_uri, "/rtp/192.0.2.10:5540/live");
+    }
+    {
+        // Removal loops until no occurrence remains, so a split escape that
+        // re-forms after the first removal is still stripped.
+        RequestInfo i = P("GET /a%5%5CC%5Cb HTTP/1.1");
+        CHECK_EQ(i.raw_uri, "/ab");
+        CHECK_EQ(first_raw_byte(i.raw_uri, '\\'), NPOS_OK);
+    }
+    {
+        // Multiple backslashes anywhere, including the query string.
+        RequestInfo i = P("GET /rtp/192.0.2.10:5540/a\\b\\c?k=v\\w HTTP/1.1");
+        CHECK_EQ(i.raw_uri, "/rtp/192.0.2.10:5540/abc?k=vw");
+        CHECK_EQ(param(i, "k"), "vw");
+    }
+    {
+        // Double-encoding is left alone: %255C is not a backslash yet.
+        RequestInfo i = P("GET /a%255Cb HTTP/1.1");
+        CHECK_EQ(i.raw_uri, "/a%255Cb");
+    }
+
+    // ------------------------------------------------------------------
+    SUITE("query parameters");
+    // ------------------------------------------------------------------
+    ServerConfig::setToken("");
+    {
+        RequestInfo i = P("GET /rtp/192.0.2.10:5540/live?a=1&b=two&c= HTTP/1.1");
+        CHECK_EQ(i.params.size(), static_cast<size_t>(3));
+        CHECK_EQ(param(i, "a"), "1");
+        CHECK_EQ(param(i, "b"), "two");
+        CHECK_EQ(param(i, "c"), "");
+        CHECK_EQ(i.clean_uri, "/rtp/192.0.2.10:5540/live?a=1&b=two&c=");
+    }
+    {
+        // A value containing '=' keeps everything after the first '='.
+        RequestInfo i = P("GET /x?sig=a=b=c HTTP/1.1");
+        CHECK_EQ(param(i, "sig"), "a=b=c");
+    }
+    {
+        // A valueless fragment is not a parameter but is preserved in the URI.
+        RequestInfo i = P("GET /x?flag&a=1 HTTP/1.1");
+        CHECK_EQ(has_param(i, "flag"), false);
+        CHECK_EQ(param(i, "a"), "1");
+        CHECK_EQ(i.clean_uri, "/x?flag&a=1");
+    }
+    {
+        // No query string at all: clean_uri is the raw URI and params is empty.
+        RequestInfo i = P("GET /rtp/192.0.2.10:5540/live HTTP/1.1");
+        CHECK_EQ(i.params.empty(), true);
+        CHECK_EQ(i.clean_uri, "/rtp/192.0.2.10:5540/live");
+    }
+    {
+        // Later duplicates win in the params map.
+        RequestInfo i = P("GET /x?a=1&a=2 HTTP/1.1");
+        CHECK_EQ(param(i, "a"), "2");
+    }
+
+    // ------------------------------------------------------------------
+    SUITE("authorization: no token configured");
+    // ------------------------------------------------------------------
+    ServerConfig::setToken("");
+    {
+        // Empty configured token disables auth entirely.
+        CHECK_EQ(P("GET /rtp/192.0.2.10:5540/live HTTP/1.1").is_authorized, true);
+        CHECK_EQ(P("GET /status HTTP/1.1").is_authorized, true);
+        CHECK_EQ(P("DESCRIBE /rtp/192.0.2.10:5540/live RTSP/1.0").is_authorized, true);
+    }
+    {
+        // A token supplied when none is configured is still stripped from the
+        // URI so it can never be forwarded upstream.
+        RequestInfo i = P("GET /rtp/192.0.2.10:5540/live?token=whatever HTTP/1.1");
+        CHECK_EQ(i.is_authorized, true);
+        CHECK_EQ(i.clean_uri, "/rtp/192.0.2.10:5540/live");
+        CHECK_EQ(param(i, "token"), "whatever");
+    }
+
+    // ------------------------------------------------------------------
+    SUITE("authorization: token configured");
+    // ------------------------------------------------------------------
+    ServerConfig::setToken("s3cr3t");
+    {
+        // Correct token -> authorized, and removed from clean_uri (and from the
+        // derived upstream URL) so the secret never leaks to the upstream.
+        RequestInfo i = P("GET /rtp/192.0.2.10:5540/live?token=s3cr3t HTTP/1.1");
+        CHECK_EQ(i.is_authorized, true);
+        CHECK_EQ(i.clean_uri, "/rtp/192.0.2.10:5540/live");
+        CHECK_EQ(i.clean_uri.find("token"), std::string::npos);
+        CHECK_EQ(i.upstream_url, "rtsp://192.0.2.10:5540/live");
+        // The raw URI is untouched and still carries the token.
+        CHECK_EQ(i.raw_uri, "/rtp/192.0.2.10:5540/live?token=s3cr3t");
+    }
+    {
+        // The token is removed from the middle of the query string and the
+        // remaining parameters keep their order and separators.
+        RequestInfo i = P("GET /tv/192.0.2.10:554/ch?a=1&token=s3cr3t&b=2 HTTP/1.1");
+        CHECK_EQ(i.is_authorized, true);
+        CHECK_EQ(i.clean_uri, "/tv/192.0.2.10:554/ch?a=1&b=2");
+        CHECK_EQ(i.upstream_url, "rtsp://192.0.2.10:554/ch?a=1&b=2");
+    }
+    {
+        // Wrong token -> not authorized.
+        RequestInfo i = P("GET /rtp/192.0.2.10:5540/live?token=wrong HTTP/1.1");
+        CHECK_EQ(i.is_authorized, false);
+        CHECK_EQ(param(i, "token"), "wrong");
+        // It is still stripped from clean_uri, which is the safe direction.
+        CHECK_EQ(i.clean_uri, "/rtp/192.0.2.10:5540/live");
+    }
+    {
+        // Missing token -> not authorized, URI untouched.
+        RequestInfo i = P("GET /rtp/192.0.2.10:5540/live HTTP/1.1");
+        CHECK_EQ(i.is_authorized, false);
+        CHECK_EQ(i.clean_uri, "/rtp/192.0.2.10:5540/live");
+    }
+    {
+        // Prefix/suffix of the real token must not authorize.
+        CHECK_EQ(P("GET /x?token=s3cr3 HTTP/1.1").is_authorized, false);
+        CHECK_EQ(P("GET /x?token=s3cr3tt HTTP/1.1").is_authorized, false);
+        CHECK_EQ(P("GET /x?token= HTTP/1.1").is_authorized, false);
+    }
+    {
+        // The parameter name is matched exactly: "TOKEN" is a normal parameter,
+        // so it neither authorizes nor gets stripped.
+        RequestInfo i = P("GET /x?TOKEN=s3cr3t HTTP/1.1");
+        CHECK_EQ(i.is_authorized, false);
+        CHECK_EQ(i.clean_uri, "/x?TOKEN=s3cr3t");
+    }
+    {
+        // Any occurrence of the correct token authorizes, even alongside a
+        // wrong one.
+        CHECK_EQ(P("GET /x?token=wrong&token=s3cr3t HTTP/1.1").is_authorized, true);
+    }
+    {
+        // A token carrying an escape byte is sanitized before comparison, so it
+        // cannot match -- injection attempts fail closed.
+        RequestInfo i = P("GET /x?token=s3cr3t\x1b HTTP/1.1");
+        CHECK_EQ(i.is_authorized, false);
+        CHECK_EQ(param(i, "token"), "s3cr3t\\x1b");
+    }
+
+    // ------------------------------------------------------------------
+    SUITE("upstream_url derivation");
+    // ------------------------------------------------------------------
+    ServerConfig::setToken("");
+    {
+        RequestInfo i = P("GET /rtp/192.0.2.10:5540/live HTTP/1.1");
+        CHECK_EQ(i.upstream_url, "rtsp://192.0.2.10:5540/live");
+    }
+    {
+        RequestInfo i = P("GET /tv/192.0.2.20:554/channel1 HTTP/1.1");
+        CHECK_EQ(i.upstream_url, "rtsp://192.0.2.20:554/channel1");
+    }
+    {
+        // A /tv/ URL with a query string goes through the (empty by default)
+        // rewrite template list and comes out unchanged.
+        RequestInfo i = P("GET /tv/192.0.2.20:554/ch?start=1&end=2 HTTP/1.1");
+        CHECK_EQ(i.upstream_url, "rtsp://192.0.2.20:554/ch?start=1&end=2");
+    }
+    {
+        // Paths that match neither prefix produce no upstream at all.
+        CHECK_EQ(P("GET / HTTP/1.1").upstream_url, "");
+        CHECK_EQ(P("GET /status HTTP/1.1").upstream_url, "");
+        CHECK_EQ(P("GET /api/logs?n=10 HTTP/1.1").upstream_url, "");
+    }
+    {
+        // Prefix with nothing after it is rejected instead of yielding "rtsp://".
+        CHECK_EQ(P("GET /rtp/ HTTP/1.1").upstream_url, "");
+        CHECK_EQ(P("GET /tv/ HTTP/1.1").upstream_url, "");
+    }
+    {
+        // Derivation happens after backslash stripping and token removal.
+        ServerConfig::setToken("s3cr3t");
+        RequestInfo i = P("GET /rtp%5C/192.0.2.10:5540/live?token=s3cr3t HTTP/1.1");
+        CHECK_EQ(i.upstream_url, "rtsp://192.0.2.10:5540/live");
+        ServerConfig::setToken("");
+    }
+
+    // ------------------------------------------------------------------
+    SUITE("upstream_url: unanchored prefix search");
+    // ------------------------------------------------------------------
+    ServerConfig::setToken("");
+    {
+        // find("/rtp/") is not anchored to the start of the path, so "/rtp/"
+        // appearing anywhere -- here only inside a query parameter value on an
+        // unrelated endpoint -- is enough to make the parser build an upstream
+        // URL out of it. An attacker-supplied query parameter therefore picks
+        // the upstream host: this should be a prefix test on the path.
+        RequestInfo i = P("GET /index?x=/rtp/192.0.2.1:554/s HTTP/1.1");
+        CHECK_EQ(i.clean_uri, "/index?x=/rtp/192.0.2.1:554/s");
+        std::printf("  [ NOTE ] /index?x=/rtp/... yields upstream_url = %s\n",
+                    tst::show(i.upstream_url).c_str());
+        XCHECK_EQ(i.upstream_url, "",
+                  "unanchored find(\"/rtp/\"): a /rtp/ inside the query string of an "
+                  "unrelated path still sets upstream_url (attacker picks the upstream)");
+    }
+    {
+        // Same defect via a path that merely contains the prefix deeper down.
+        RequestInfo i = P("GET /static/rtp/192.0.2.1:554/s HTTP/1.1");
+        XCHECK_EQ(i.upstream_url, "",
+                  "unanchored find(\"/rtp/\"): /static/rtp/... is not a stream path but "
+                  "still resolves to an upstream");
+    }
+    {
+        // /rtp/ is searched before /tv/, so on a genuine /tv/ path that happens
+        // to contain "/rtp/" later the wrong (and much shorter) sub-path wins.
+        RequestInfo i = P("GET /tv/192.0.2.20:554/a/rtp/x HTTP/1.1");
+        std::printf("  [ NOTE ] /tv/...a/rtp/x yields upstream_url = %s\n",
+                    tst::show(i.upstream_url).c_str());
+        XCHECK_EQ(i.upstream_url, "rtsp://192.0.2.20:554/a/rtp/x",
+                  "the /rtp/ search runs first and is unanchored, so a /tv/ path "
+                  "containing /rtp/ is truncated to the /rtp/ suffix");
+    }
+
+    ServerConfig::setToken("");
+    return tst::summary();
+}

--- a/test/unit/test_rtp_pipeline.cpp
+++ b/test/unit/test_rtp_pipeline.cpp
@@ -1,0 +1,633 @@
+// Unit tests for RtpPipeline (src/protocol/rtp_pipeline.cpp).
+//
+// Every RTP packet is assembled byte-by-byte here so the expectations are
+// readable against RFC 3550 / ISO 13818-1 rather than against a fixture blob.
+//
+// No network, no filesystem, no timing: the pipeline is pure buffer surgery.
+// ServerConfig is process-wide static state, so every group sets the two flags
+// it reads (strip_padding, wait_keyframe) explicitly and rebuilds/resets the
+// pipeline, making the groups order-independent.
+
+#include "test_harness.h"
+
+#include "core/server_config.h"
+#include "protocol/rtp_pipeline.h"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Packet builders
+// ---------------------------------------------------------------------------
+
+// Bytes used as inert filler. 0xAA can never form a 00 00 01 start code and is
+// never a valid PID byte pattern we care about.
+static const uint8_t FILL = 0xAA;
+
+// 12-byte (+ 4*cc) RTP header, version 2.
+static std::vector<uint8_t> rtp_header(uint8_t cc = 0, bool ext = false,
+                                       bool pad = false)
+{
+    std::vector<uint8_t> p(12, 0);
+    p[0] = static_cast<uint8_t>(0x80 | (pad ? 0x20 : 0) | (ext ? 0x10 : 0) |
+                                (cc & 0x0F));
+    p[1] = 33;   // PT = MP2T
+    p[2] = 0x00; // seq
+    p[3] = 0x01;
+    p.resize(static_cast<size_t>(12 + cc * 4), 0); // CSRC list
+    return p;
+}
+
+// Appends a 4-byte RTP extension header carrying `ext_words` 32-bit words.
+// The words themselves are NOT appended unless `with_body` is set, which is how
+// the hostile-length cases are built.
+static void append_ext_header(std::vector<uint8_t> &p, uint16_t ext_words,
+                              bool with_body)
+{
+    p.push_back(0xBE);
+    p.push_back(0xDE);
+    p.push_back(static_cast<uint8_t>(ext_words >> 8));
+    p.push_back(static_cast<uint8_t>(ext_words & 0xFF));
+    if (with_body)
+        p.insert(p.end(), static_cast<size_t>(ext_words) * 4, FILL);
+}
+
+static void append(std::vector<uint8_t> &a, const std::vector<uint8_t> &b)
+{
+    a.insert(a.end(), b.begin(), b.end());
+}
+
+// A 188-byte TS packet, adaptation_field_control = 1 (payload only).
+// `tag` lands at byte 4 so in-place compaction can be traced.
+static std::vector<uint8_t> make_ts(uint16_t pid, uint8_t tag = FILL)
+{
+    std::vector<uint8_t> ts(188, FILL);
+    ts[0] = 0x47;
+    ts[1] = static_cast<uint8_t>((pid >> 8) & 0x1F);
+    ts[2] = static_cast<uint8_t>(pid & 0xFF);
+    ts[3] = 0x10; // afc = 1, cc = 0
+    ts[4] = tag;
+    return ts;
+}
+
+// TS packet whose payload contains a 00 00 01 start code followed by `nal`.
+static std::vector<uint8_t> make_ts_nal(uint16_t pid, uint8_t nal)
+{
+    std::vector<uint8_t> ts = make_ts(pid);
+    ts[10] = 0x00;
+    ts[11] = 0x00;
+    ts[12] = 0x01;
+    ts[13] = nal;
+    return ts;
+}
+
+// TS packet with an adaptation field carrying the random access indicator.
+static std::vector<uint8_t> make_ts_rai(uint16_t pid)
+{
+    std::vector<uint8_t> ts(188, FILL);
+    ts[0] = 0x47;
+    ts[1] = static_cast<uint8_t>((pid >> 8) & 0x1F);
+    ts[2] = static_cast<uint8_t>(pid & 0xFF);
+    ts[3] = 0x30; // afc = 3 (adaptation field + payload)
+    ts[4] = 7;    // adaptation_field_length
+    ts[5] = 0x40; // random_access_indicator
+    return ts;
+}
+
+// Runs the gate on a single-TS-packet RTP datagram and reports whether the
+// packet was forwarded (i.e. whether the keyframe gate opened).
+static bool gate_opens_for(const std::vector<uint8_t> &ts)
+{
+    ServerConfig::setStripPadding(false);
+    ServerConfig::setWaitKeyframe(true);
+    RtpPipeline pipe;
+    pipe.reset();
+
+    std::vector<uint8_t> buf = rtp_header();
+    append(buf, ts);
+    size_t len = buf.size();
+    return pipe.process(buf.data(), len);
+}
+
+// ---------------------------------------------------------------------------
+
+int main()
+{
+    // -----------------------------------------------------------------
+    SUITE("rtp_pipeline: version bits and minimum length");
+    {
+        ServerConfig::setStripPadding(false);
+        ServerConfig::setWaitKeyframe(false);
+        RtpPipeline pipe;
+        pipe.reset();
+
+        size_t off = 0;
+
+        // Too short: an RTP header is 12 bytes minimum.
+        std::vector<uint8_t> shortpkt(11, 0);
+        shortpkt[0] = 0x80;
+        size_t len = shortpkt.size();
+        CHECK(!RtpPipeline::get_payload_offset(shortpkt.data(), len, off));
+        CHECK(!pipe.process(shortpkt.data(), len));
+
+        // Version must be 2 -> top two bits == 0b10.
+        for (uint8_t v : {uint8_t(0x00), uint8_t(0x40), uint8_t(0xC0)})
+        {
+            std::vector<uint8_t> p = rtp_header();
+            p[0] = static_cast<uint8_t>(v | (p[0] & 0x3F));
+            size_t l = p.size();
+            CHECK(!RtpPipeline::get_payload_offset(p.data(), l, off));
+            CHECK(!pipe.process(p.data(), l));
+        }
+
+        // Version 2 with no payload is a well-formed (if empty) packet.
+        std::vector<uint8_t> ok = rtp_header();
+        size_t okl = ok.size();
+        off = 12345;
+        CHECK(RtpPipeline::get_payload_offset(ok.data(), okl, off));
+        CHECK_EQ(off, size_t(12));
+        CHECK(pipe.process(ok.data(), okl));
+        CHECK_EQ(okl, size_t(12));
+    }
+
+    // -----------------------------------------------------------------
+    SUITE("get_payload_offset: CSRC count");
+    {
+        size_t off = 0;
+
+        std::vector<uint8_t> cc1 = rtp_header(1);
+        cc1.insert(cc1.end(), 4, FILL);
+        size_t l1 = cc1.size();
+        CHECK(RtpPipeline::get_payload_offset(cc1.data(), l1, off));
+        CHECK_EQ(off, size_t(16));
+
+        std::vector<uint8_t> cc4 = rtp_header(4);
+        cc4.insert(cc4.end(), 8, FILL);
+        size_t l4 = cc4.size();
+        CHECK(RtpPipeline::get_payload_offset(cc4.data(), l4, off));
+        CHECK_EQ(off, size_t(28));
+
+        // cc = 15 -> header is exactly 72 bytes; a 72-byte packet is legal but
+        // carries no payload.
+        std::vector<uint8_t> cc15 = rtp_header(15);
+        size_t l15 = cc15.size();
+        CHECK_EQ(l15, size_t(72));
+        CHECK(RtpPipeline::get_payload_offset(cc15.data(), l15, off));
+        CHECK_EQ(off, size_t(72));
+
+        // One byte short of the declared CSRC list must be rejected.
+        size_t l15short = 71;
+        CHECK(!RtpPipeline::get_payload_offset(cc15.data(), l15short, off));
+    }
+
+    // -----------------------------------------------------------------
+    SUITE("get_payload_offset: extension header (incl. hostile lengths)");
+    {
+        size_t off = 0;
+
+        // ext with 0 words -> payload begins right after the 4-byte ext header.
+        std::vector<uint8_t> e0 = rtp_header(0, true);
+        append_ext_header(e0, 0, true);
+        e0.insert(e0.end(), 4, FILL);
+        size_t le0 = e0.size();
+        CHECK(RtpPipeline::get_payload_offset(e0.data(), le0, off));
+        CHECK_EQ(off, size_t(16));
+
+        // ext with 1 word.
+        std::vector<uint8_t> e1 = rtp_header(0, true);
+        append_ext_header(e1, 1, true);
+        e1.insert(e1.end(), 4, FILL);
+        size_t le1 = e1.size();
+        CHECK(RtpPipeline::get_payload_offset(e1.data(), le1, off));
+        CHECK_EQ(off, size_t(20));
+
+        // CSRC list and extension combined: 12 + 2*4 + 4 + 3*4 = 36.
+        std::vector<uint8_t> ec = rtp_header(2, true);
+        append_ext_header(ec, 3, true);
+        ec.insert(ec.end(), 8, FILL);
+        size_t lec = ec.size();
+        CHECK(RtpPipeline::get_payload_offset(ec.data(), lec, off));
+        CHECK_EQ(off, size_t(36));
+
+        // Extension that consumes the whole packet: offset == len is allowed
+        // (zero-length payload), not an error.
+        std::vector<uint8_t> efull = rtp_header(0, true);
+        append_ext_header(efull, 2, true);
+        size_t lef = efull.size();
+        CHECK_EQ(lef, size_t(24));
+        CHECK(RtpPipeline::get_payload_offset(efull.data(), lef, off));
+        CHECK_EQ(off, size_t(24));
+
+        // Extension bit set but the 4-byte extension header is truncated: the
+        // length field itself is out of bounds, so this must be rejected
+        // *before* it is read.
+        std::vector<uint8_t> etrunc = rtp_header(0, true);
+        etrunc.push_back(0xBE);
+        etrunc.push_back(0xDE);
+        size_t let = etrunc.size();
+        CHECK_EQ(let, size_t(14));
+        CHECK(!RtpPipeline::get_payload_offset(etrunc.data(), let, off));
+
+        // Hostile: declared extension length far exceeds the datagram. The
+        // buffer is heap-allocated at its exact size, so any out-of-bounds read
+        // is a real one; the packet must simply be rejected.
+        for (uint16_t words : {uint16_t(0x0002), uint16_t(0x0100),
+                               uint16_t(0x4000), uint16_t(0xFFFF)})
+        {
+            std::vector<uint8_t> h = rtp_header(0, true);
+            append_ext_header(h, words, false); // body deliberately absent
+            h.insert(h.end(), 4, FILL);
+            size_t lh = h.size();
+            CHECK_EQ(lh, size_t(20));
+            off = 0xDEAD;
+            CHECK(!RtpPipeline::get_payload_offset(h.data(), lh, off));
+            CHECK_EQ(off, size_t(0xDEAD)); // untouched on failure
+        }
+
+        // A packet whose extension header cannot be parsed is malformed and
+        // should not be relayed to the client at all.
+        {
+            ServerConfig::setStripPadding(true);
+            ServerConfig::setWaitKeyframe(false);
+            RtpPipeline pipe;
+            pipe.reset();
+
+            std::vector<uint8_t> h = rtp_header(0, true);
+            append_ext_header(h, 0xFFFF, false);
+            h.insert(h.end(), 4, FILL);
+            size_t lh = h.size();
+            XCHECK(!pipe.process(h.data(), lh),
+                   "process() only validates version/length; a packet with an "
+                   "unparseable extension header is forwarded verbatim");
+        }
+    }
+
+    // -----------------------------------------------------------------
+    SUITE("RTP padding: valid padding_len");
+    {
+        ServerConfig::setStripPadding(true);
+        ServerConfig::setWaitKeyframe(false);
+        RtpPipeline pipe;
+        pipe.reset();
+
+        // 10 payload bytes, the last 4 of which are padding.
+        std::vector<uint8_t> p = rtp_header(0, false, true);
+        p.insert(p.end(), 10, FILL);
+        p[p.size() - 1] = 4; // padding_len
+        size_t len = p.size();
+        CHECK_EQ(len, size_t(22));
+
+        CHECK(pipe.process(p.data(), len));
+        CHECK_EQ(len, size_t(18));       // 22 - 4
+        CHECK_EQ(p[0] & 0x20, 0);        // P bit cleared once padding is gone
+        CHECK_EQ(p[0] & 0xC0, 0x80);     // version untouched
+
+        // padding_len covering the entire payload leaves an empty payload.
+        std::vector<uint8_t> q = rtp_header(0, false, true);
+        q.insert(q.end(), 10, FILL);
+        q[q.size() - 1] = 10;
+        size_t qlen = q.size();
+        CHECK(pipe.process(q.data(), qlen));
+        CHECK_EQ(qlen, size_t(12));
+        CHECK_EQ(q[0] & 0x20, 0);
+    }
+
+    // -----------------------------------------------------------------
+    SUITE("RTP padding: malformed padding_len (known bug)");
+    {
+        ServerConfig::setStripPadding(true);
+        ServerConfig::setWaitKeyframe(false);
+        RtpPipeline pipe;
+        pipe.reset();
+
+        // padding_len == 0 is illegal (RFC 3550: the last octet counts itself,
+        // so it is >= 1). Nothing is stripped -- correct -- but the P bit must
+        // not be cleared, or the receiver will decode the padding as payload.
+        std::vector<uint8_t> z = rtp_header(0, false, true);
+        z.insert(z.end(), 10, FILL);
+        z[z.size() - 1] = 0;
+        size_t zlen = z.size();
+        CHECK(pipe.process(z.data(), zlen));
+        CHECK_EQ(zlen, size_t(22)); // length correctly left alone
+        XCHECK_EQ(z[0] & 0x20, 0x20,
+                  "padding bit is cleared unconditionally even when "
+                  "padding_len==0 was not stripped, so the padding octets are "
+                  "handed to the decoder as payload");
+
+        // padding_len larger than the payload is equally illegal.
+        std::vector<uint8_t> b = rtp_header(0, false, true);
+        b.insert(b.end(), 10, FILL);
+        b[b.size() - 1] = 200;
+        size_t blen = b.size();
+        CHECK(pipe.process(b.data(), blen));
+        CHECK_EQ(blen, size_t(22)); // no under-run of the buffer
+        XCHECK_EQ(b[0] & 0x20, 0x20,
+                  "padding bit is cleared unconditionally even when "
+                  "padding_len(200) > payload(10) was not stripped");
+
+        // With stripping disabled the packet must be passed through untouched,
+        // padding bit included.
+        ServerConfig::setStripPadding(false);
+        RtpPipeline pass;
+        pass.reset();
+        std::vector<uint8_t> k = rtp_header(0, false, true);
+        k.insert(k.end(), 10, FILL);
+        k[k.size() - 1] = 4;
+        size_t klen = k.size();
+        CHECK(pass.process(k.data(), klen));
+        CHECK_EQ(klen, size_t(22));
+        CHECK_EQ(k[0] & 0x20, 0x20);
+    }
+
+    // -----------------------------------------------------------------
+    SUITE("TS null-packet (PID 0x1FFF) stripping");
+    {
+        ServerConfig::setStripPadding(true);
+        ServerConfig::setWaitKeyframe(false);
+        RtpPipeline pipe;
+        pipe.reset();
+
+        // real / null / real -> the two real packets must be compacted to the
+        // front, in order.
+        std::vector<uint8_t> m = rtp_header();
+        append(m, make_ts(0x0100, 0x11));
+        append(m, make_ts(0x1FFF, 0x22));
+        append(m, make_ts(0x0101, 0x33));
+        size_t mlen = m.size();
+        CHECK_EQ(mlen, size_t(12 + 3 * 188));
+        CHECK(pipe.process(m.data(), mlen));
+        CHECK_EQ(mlen, size_t(12 + 2 * 188));
+        CHECK_EQ(m[12 + 4], uint8_t(0x11));       // first real packet stays put
+        CHECK_EQ(m[12 + 188 + 4], uint8_t(0x33)); // third moved into slot 2
+        CHECK_EQ(m[12 + 188 + 2], uint8_t(0x01)); // ...with its PID intact
+        CHECK_EQ(m[12 + 1] & 0x1F, 0x01);
+
+        // A single real packet is untouched.
+        std::vector<uint8_t> s = rtp_header();
+        append(s, make_ts(0x0100, 0x44));
+        size_t slen = s.size();
+        CHECK(pipe.process(s.data(), slen));
+        CHECK_EQ(slen, size_t(12 + 188));
+        CHECK_EQ(s[12 + 4], uint8_t(0x44));
+
+        // An all-null datagram collapses to nothing and must be dropped.
+        std::vector<uint8_t> n = rtp_header();
+        append(n, make_ts(0x1FFF, 0x55));
+        append(n, make_ts(0x1FFF, 0x66));
+        size_t nlen = n.size();
+        CHECK(!pipe.process(n.data(), nlen));
+        CHECK_EQ(nlen, size_t(0));
+
+        // Not MPEG-TS (no 0x47 sync byte): leave the payload alone even though
+        // it happens to be 188-byte aligned.
+        std::vector<uint8_t> nt = rtp_header();
+        std::vector<uint8_t> raw = make_ts(0x1FFF, 0x77);
+        raw[0] = 0x48; // broken sync byte
+        append(nt, raw);
+        size_t ntlen = nt.size();
+        CHECK(pipe.process(nt.data(), ntlen));
+        CHECK_EQ(ntlen, size_t(12 + 188));
+
+        // Stripping disabled: nulls survive.
+        ServerConfig::setStripPadding(false);
+        RtpPipeline keep;
+        keep.reset();
+        std::vector<uint8_t> d = rtp_header();
+        append(d, make_ts(0x1FFF, 0x88));
+        append(d, make_ts(0x0100, 0x99));
+        size_t dlen = d.size();
+        CHECK(keep.process(d.data(), dlen));
+        CHECK_EQ(dlen, size_t(12 + 2 * 188));
+        CHECK_EQ(d[12 + 4], uint8_t(0x88));
+    }
+
+    // -----------------------------------------------------------------
+    SUITE("TS stripping: payload not a multiple of 188");
+    {
+        ServerConfig::setStripPadding(true);
+        ServerConfig::setWaitKeyframe(false);
+        RtpPipeline pipe;
+        pipe.reset();
+
+        std::vector<uint8_t> t = rtp_header();
+        append(t, make_ts(0x0100, 0x12));
+        t.insert(t.end(), 100, 0x5A); // trailing partial TS packet
+        size_t tlen = t.size();
+        CHECK_EQ(tlen, size_t(12 + 188 + 100));
+
+        CHECK(pipe.process(t.data(), tlen));
+        CHECK_EQ(t[12 + 4], uint8_t(0x12)); // the whole packet is preserved
+        XCHECK_EQ(tlen, size_t(12 + 188 + 100),
+                  "the compaction loop rewrites len from whole 188-byte units "
+                  "only, so a trailing partial TS packet is silently discarded "
+                  "instead of being forwarded or buffered");
+
+        // Same shape but with the real packet nulled out: the partial tail is
+        // discarded along with it and the datagram vanishes entirely.
+        std::vector<uint8_t> u = rtp_header();
+        append(u, make_ts(0x1FFF, 0x13));
+        u.insert(u.end(), 100, 0x5A);
+        size_t ulen = u.size();
+        CHECK(!pipe.process(u.data(), ulen));
+        CHECK_EQ(ulen, size_t(0));
+
+        // Payload shorter than one TS packet is left alone (no 188-byte unit).
+        std::vector<uint8_t> v = rtp_header();
+        v.insert(v.end(), 100, 0x47);
+        size_t vlen = v.size();
+        CHECK(pipe.process(v.data(), vlen));
+        CHECK_EQ(vlen, size_t(12 + 100));
+    }
+
+    // -----------------------------------------------------------------
+    SUITE("padding + TS stripping combined");
+    {
+        ServerConfig::setStripPadding(true);
+        ServerConfig::setWaitKeyframe(false);
+        RtpPipeline pipe;
+        pipe.reset();
+
+        // 2 TS packets (one null) plus 6 padding octets.
+        std::vector<uint8_t> p = rtp_header(0, false, true);
+        append(p, make_ts(0x1FFF, 0x01));
+        append(p, make_ts(0x0100, 0x02));
+        p.insert(p.end(), 6, 0x00);
+        p[p.size() - 1] = 6; // padding_len
+        size_t len = p.size();
+        CHECK_EQ(len, size_t(12 + 376 + 6));
+
+        CHECK(pipe.process(p.data(), len));
+        CHECK_EQ(len, size_t(12 + 188)); // padding gone, null packet gone
+        CHECK_EQ(p[12 + 4], uint8_t(0x02));
+        CHECK_EQ(p[0] & 0x20, 0);
+    }
+
+    // -----------------------------------------------------------------
+    SUITE("keyframe gate: genuine keyframes open it");
+    {
+        // H.264: IDR (5), SPS (7), PPS (8). nal_ref_idc = 3 -> 0x60 | type.
+        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x65))); // IDR slice
+        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x67))); // SPS
+        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x68))); // PPS
+
+        // H.265: nal type lives in bits 1..6. VPS=32, SPS=33, PPS=34, IDR_W_RADL=19.
+        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x40))); // VPS
+        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x42))); // SPS
+        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x44))); // PPS
+        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x26))); // IDR_W_RADL
+
+        // Adaptation-field random access indicator.
+        CHECK(gate_opens_for(make_ts_rai(0x0100)));
+
+        // Once open, the gate stays open for ordinary inter frames.
+        ServerConfig::setStripPadding(false);
+        ServerConfig::setWaitKeyframe(true);
+        RtpPipeline pipe;
+        pipe.reset();
+
+        std::vector<uint8_t> inter = rtp_header();
+        append(inter, make_ts(0x0100, 0x01));
+        size_t ilen = inter.size();
+        CHECK(!pipe.process(inter.data(), ilen)); // dropped before the IDR
+
+        std::vector<uint8_t> idr = rtp_header();
+        append(idr, make_ts_nal(0x0100, 0x65));
+        size_t dlen = idr.size();
+        CHECK(pipe.process(idr.data(), dlen));
+
+        size_t ilen2 = inter.size();
+        CHECK(pipe.process(inter.data(), ilen2)); // now forwarded
+
+        // reset() re-arms the gate from ServerConfig.
+        pipe.reset();
+        size_t ilen3 = inter.size();
+        CHECK(!pipe.process(inter.data(), ilen3));
+
+        // ...and reset() with the feature off leaves the gate permanently open.
+        ServerConfig::setWaitKeyframe(false);
+        pipe.reset();
+        size_t ilen4 = inter.size();
+        CHECK(pipe.process(inter.data(), ilen4));
+    }
+
+    // -----------------------------------------------------------------
+    SUITE("keyframe gate: ordinary data keeps it closed");
+    {
+        // Plain TS payload, no start codes, no RAI.
+        CHECK(!gate_opens_for(make_ts(0x0100, 0x01)));
+
+        // H.264 non-IDR slice with nal_ref_idc = 3 (0x61): type 1.
+        CHECK(!gate_opens_for(make_ts_nal(0x0100, 0x61)));
+
+        // H.264 SEI (6) and AUD (9) are not random access points.
+        CHECK(!gate_opens_for(make_ts_nal(0x0100, 0x06)));
+        CHECK(!gate_opens_for(make_ts_nal(0x0100, 0x09)));
+
+        // Adaptation field present but the random access indicator is clear.
+        {
+            std::vector<uint8_t> ts = make_ts_rai(0x0100);
+            ts[5] = 0x00;
+            CHECK(!gate_opens_for(ts));
+        }
+        // Adaptation field length 0 -> nothing to read, no RAI.
+        {
+            std::vector<uint8_t> ts = make_ts_rai(0x0100);
+            ts[4] = 0;
+            CHECK(!gate_opens_for(ts));
+        }
+
+        // Not MPEG-TS at all.
+        {
+            std::vector<uint8_t> ts = make_ts_nal(0x0100, 0x65);
+            ts[0] = 0x48; // broken sync byte
+            CHECK(!gate_opens_for(ts));
+        }
+
+        // Shorter than one TS packet: nothing to scan.
+        {
+            ServerConfig::setStripPadding(false);
+            ServerConfig::setWaitKeyframe(true);
+            RtpPipeline pipe;
+            pipe.reset();
+            std::vector<uint8_t> p = rtp_header();
+            std::vector<uint8_t> ts = make_ts_nal(0x0100, 0x65);
+            p.insert(p.end(), ts.begin(), ts.begin() + 100);
+            size_t len = p.size();
+            CHECK(!pipe.process(p.data(), len));
+            CHECK_EQ(len, size_t(112)); // len untouched when dropped
+        }
+    }
+
+    // -----------------------------------------------------------------
+    SUITE("keyframe gate: KNOWN BUGS (false keyframes)");
+    {
+        // 0x41 is an H.264 non-IDR slice (nal_ref_idc=2, type=1) -- by far the
+        // most common byte after a start code in a live stream. The H.265 test
+        // runs unconditionally on the same byte: (0x41 >> 1) & 0x3F == 32,
+        // which is read as a VPS, so the gate opens on the very first P-slice.
+        XCHECK(!gate_opens_for(make_ts_nal(0x0100, 0x41)),
+               "0x41 (H.264 non-IDR slice) satisfies the H.265 test "
+               "(0x41>>1)&0x3F==32 (VPS) and falsely opens the keyframe gate; "
+               "the codec is never checked before applying the H.265 rule");
+
+        // 0xC0 is the MPEG-1/2 audio PES stream_id -- it follows a 00 00 01
+        // PES start code in every audio packet. (0xC0 >> 1) & 0x3F == 32 too.
+        XCHECK(!gate_opens_for(make_ts_nal(0x0100, 0xC0)),
+               "0xC0 (MPEG audio PES stream_id after a 00 00 01 PES start "
+               "code) also maps to H.265 nal type 32 (VPS) and falsely opens "
+               "the keyframe gate");
+
+        // 0xC1..0xDF (further audio stream_ids) collide the same way.
+        XCHECK(!gate_opens_for(make_ts_nal(0x0100, 0xC1)),
+               "0xC1 (second MPEG audio PES stream_id) maps to H.265 nal type "
+               "32 as well");
+
+        // A PAT carries no video at all; joining on it means the client still
+        // has to wait for the next real IDR, and meanwhile gets broken frames.
+        {
+            std::vector<uint8_t> pat = make_ts(0x0000, 0x01);
+            XCHECK(!gate_opens_for(pat),
+                   "a bare PAT (PID 0) opens the keyframe gate on its own, so "
+                   "forwarding starts mid-GOP even though no keyframe has been "
+                   "seen");
+        }
+
+        // Same, buried after real null packets: still opens on the PAT.
+        {
+            ServerConfig::setStripPadding(false);
+            ServerConfig::setWaitKeyframe(true);
+            RtpPipeline pipe;
+            pipe.reset();
+            std::vector<uint8_t> p = rtp_header();
+            append(p, make_ts(0x0100, 0x01)); // ordinary payload
+            append(p, make_ts(0x0000, 0x02)); // PAT
+            size_t len = p.size();
+            XCHECK(!pipe.process(p.data(), len),
+                   "the PAT-as-keyframe shortcut also fires when the PAT is "
+                   "not the first TS packet in the datagram");
+        }
+
+        // Off-by-one at the tail of the TS payload: with afc=1 the scan window
+        // is data[0..183], but the loop guard `j + 4 < data_len` stops at
+        // j == 179, so a start code occupying the final four payload bytes is
+        // never examined and a real IDR there is missed.
+        {
+            std::vector<uint8_t> ts = make_ts(0x0100, FILL);
+            ts[184] = 0x00;
+            ts[185] = 0x00;
+            ts[186] = 0x01;
+            ts[187] = 0x65; // H.264 IDR
+            XCHECK(gate_opens_for(ts),
+                   "scan loop guard is `j + 4 < data_len` instead of "
+                   "`j + 3 < data_len`, so a start code in the last four bytes "
+                   "of a TS payload is skipped and the IDR is missed");
+        }
+
+        // Leave the shared config in a neutral state for anything that follows.
+        ServerConfig::setWaitKeyframe(false);
+        ServerConfig::setStripPadding(false);
+    }
+
+    return tst::summary();
+}

--- a/test/unit/test_rtp_pipeline.cpp
+++ b/test/unit/test_rtp_pipeline.cpp
@@ -72,13 +72,17 @@ static std::vector<uint8_t> make_ts(uint16_t pid, uint8_t tag = FILL)
 }
 
 // TS packet whose payload contains a 00 00 01 start code followed by `nal`.
-static std::vector<uint8_t> make_ts_nal(uint16_t pid, uint8_t nal)
+// `nal2` is the byte after it: the second byte of an H.265 NAL header
+// (nuh_layer_id / nuh_temporal_id_plus1), inert filler otherwise.
+static std::vector<uint8_t> make_ts_nal(uint16_t pid, uint8_t nal,
+                                        uint8_t nal2 = FILL)
 {
     std::vector<uint8_t> ts = make_ts(pid);
     ts[10] = 0x00;
     ts[11] = 0x00;
     ts[12] = 0x01;
     ts[13] = nal;
+    ts[14] = nal2;
     return ts;
 }
 
@@ -294,7 +298,7 @@ int main()
     }
 
     // -----------------------------------------------------------------
-    SUITE("RTP padding: malformed padding_len (known bug)");
+    SUITE("RTP padding: malformed padding_len");
     {
         ServerConfig::setStripPadding(true);
         ServerConfig::setWaitKeyframe(false);
@@ -310,10 +314,7 @@ int main()
         size_t zlen = z.size();
         CHECK(pipe.process(z.data(), zlen));
         CHECK_EQ(zlen, size_t(22)); // length correctly left alone
-        XCHECK_EQ(z[0] & 0x20, 0x20,
-                  "padding bit is cleared unconditionally even when "
-                  "padding_len==0 was not stripped, so the padding octets are "
-                  "handed to the decoder as payload");
+        CHECK_EQ(z[0] & 0x20, 0x20); // ...and the P bit still describes the packet
 
         // padding_len larger than the payload is equally illegal.
         std::vector<uint8_t> b = rtp_header(0, false, true);
@@ -322,9 +323,18 @@ int main()
         size_t blen = b.size();
         CHECK(pipe.process(b.data(), blen));
         CHECK_EQ(blen, size_t(22)); // no under-run of the buffer
-        XCHECK_EQ(b[0] & 0x20, 0x20,
-                  "padding bit is cleared unconditionally even when "
-                  "padding_len(200) > payload(10) was not stripped");
+        CHECK_EQ(b[0] & 0x20, 0x20);
+
+        // Null-packet stripping in the same datagram must not clear the P bit
+        // either: the padding octets are still in there.
+        std::vector<uint8_t> c = rtp_header(0, false, true);
+        append(c, make_ts(0x1FFF, 0x01));
+        append(c, make_ts(0x0100, 0x02));
+        c[c.size() - 1] = 0; // illegal padding_len
+        size_t clen = c.size();
+        CHECK(pipe.process(c.data(), clen));
+        CHECK_EQ(clen, size_t(12 + 188));
+        CHECK_EQ(c[0] & 0x20, 0x20);
 
         // With stripping disabled the packet must be passed through untouched,
         // padding bit included.
@@ -418,19 +428,32 @@ int main()
 
         CHECK(pipe.process(t.data(), tlen));
         CHECK_EQ(t[12 + 4], uint8_t(0x12)); // the whole packet is preserved
-        XCHECK_EQ(tlen, size_t(12 + 188 + 100),
-                  "the compaction loop rewrites len from whole 188-byte units "
-                  "only, so a trailing partial TS packet is silently discarded "
-                  "instead of being forwarded or buffered");
+        CHECK_EQ(tlen, size_t(12 + 188 + 100)); // ...and so is the partial tail
 
-        // Same shape but with the real packet nulled out: the partial tail is
-        // discarded along with it and the datagram vanishes entirely.
+        // Same shape but with the real packet nulled out: only the null packet
+        // goes, the partial tail moves down to take its place.
         std::vector<uint8_t> u = rtp_header();
         append(u, make_ts(0x1FFF, 0x13));
         u.insert(u.end(), 100, 0x5A);
         size_t ulen = u.size();
-        CHECK(!pipe.process(u.data(), ulen));
-        CHECK_EQ(ulen, size_t(0));
+        CHECK(pipe.process(u.data(), ulen));
+        CHECK_EQ(ulen, size_t(12 + 100));
+        CHECK_EQ(u[12], uint8_t(0x5A));
+        CHECK_EQ(u[12 + 99], uint8_t(0x5A));
+
+        // Null packet between two real ones, plus a tail: compaction keeps the
+        // order and the tail lands right behind the second real packet.
+        std::vector<uint8_t> w = rtp_header();
+        append(w, make_ts(0x0100, 0x14));
+        append(w, make_ts(0x1FFF, 0x15));
+        append(w, make_ts(0x0101, 0x16));
+        w.insert(w.end(), 50, 0x5B);
+        size_t wlen = w.size();
+        CHECK(pipe.process(w.data(), wlen));
+        CHECK_EQ(wlen, size_t(12 + 2 * 188 + 50));
+        CHECK_EQ(w[12 + 4], uint8_t(0x14));
+        CHECK_EQ(w[12 + 188 + 4], uint8_t(0x16));
+        CHECK_EQ(w[12 + 2 * 188], uint8_t(0x5B));
 
         // Payload shorter than one TS packet is left alone (no 188-byte unit).
         std::vector<uint8_t> v = rtp_header();
@@ -472,9 +495,11 @@ int main()
         CHECK(gate_opens_for(make_ts_nal(0x0100, 0x68))); // PPS
 
         // H.265: nal type lives in bits 1..6. VPS=32, SPS=33, PPS=34, IDR_W_RADL=19.
-        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x40))); // VPS
-        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x42))); // SPS
-        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x44))); // PPS
+        // The parameter sets are only accepted with a base-layer second header
+        // byte (nuh_layer_id 0, nuh_temporal_id_plus1 1 -> 0x01).
+        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x40, 0x01))); // VPS
+        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x42, 0x01))); // SPS
+        CHECK(gate_opens_for(make_ts_nal(0x0100, 0x44, 0x01))); // PPS
         CHECK(gate_opens_for(make_ts_nal(0x0100, 0x26))); // IDR_W_RADL
 
         // Adaptation-field random access indicator.
@@ -560,40 +585,37 @@ int main()
     }
 
     // -----------------------------------------------------------------
-    SUITE("keyframe gate: KNOWN BUGS (false keyframes)");
+    SUITE("keyframe gate: false keyframes are rejected");
     {
         // 0x41 is an H.264 non-IDR slice (nal_ref_idc=2, type=1) -- by far the
-        // most common byte after a start code in a live stream. The H.265 test
-        // runs unconditionally on the same byte: (0x41 >> 1) & 0x3F == 32,
-        // which is read as a VPS, so the gate opens on the very first P-slice.
-        XCHECK(!gate_opens_for(make_ts_nal(0x0100, 0x41)),
-               "0x41 (H.264 non-IDR slice) satisfies the H.265 test "
-               "(0x41>>1)&0x3F==32 (VPS) and falsely opens the keyframe gate; "
-               "the codec is never checked before applying the H.265 rule");
+        // most common byte after a start code in a live stream. It also reads as
+        // H.265 nal type (0x41 >> 1) & 0x3F == 32 (VPS), so the parameter-set
+        // test must look at the second NAL header byte before believing it.
+        CHECK(!gate_opens_for(make_ts_nal(0x0100, 0x41)));
 
-        // 0xC0 is the MPEG-1/2 audio PES stream_id -- it follows a 00 00 01
-        // PES start code in every audio packet. (0xC0 >> 1) & 0x3F == 32 too.
-        XCHECK(!gate_opens_for(make_ts_nal(0x0100, 0xC0)),
-               "0xC0 (MPEG audio PES stream_id after a 00 00 01 PES start "
-               "code) also maps to H.265 nal type 32 (VPS) and falsely opens "
-               "the keyframe gate");
+        // 0xC0..0xDF are the MPEG-1/2 audio PES stream_ids -- they follow a
+        // 00 00 01 PES start code in every audio packet and map to nal type 32
+        // as well. The forbidden_zero_bit rules the whole range out.
+        CHECK(!gate_opens_for(make_ts_nal(0x0100, 0xC0)));
+        CHECK(!gate_opens_for(make_ts_nal(0x0100, 0xC1)));
+        CHECK(!gate_opens_for(make_ts_nal(0x0100, 0xDF)));
+        CHECK(!gate_opens_for(make_ts_nal(0x0100, 0xE0))); // video PES stream_id
 
-        // 0xC1..0xDF (further audio stream_ids) collide the same way.
-        XCHECK(!gate_opens_for(make_ts_nal(0x0100, 0xC1)),
-               "0xC1 (second MPEG audio PES stream_id) maps to H.265 nal type "
-               "32 as well");
+        // Even with a plausible second byte the forbidden_zero_bit still wins.
+        CHECK(!gate_opens_for(make_ts_nal(0x0100, 0xC0, 0x01)));
+
+        // A real H.265 parameter set byte with a non base-layer second byte is
+        // not enough on its own.
+        CHECK(!gate_opens_for(make_ts_nal(0x0100, 0x40, 0x00)));
 
         // A PAT carries no video at all; joining on it means the client still
         // has to wait for the next real IDR, and meanwhile gets broken frames.
         {
             std::vector<uint8_t> pat = make_ts(0x0000, 0x01);
-            XCHECK(!gate_opens_for(pat),
-                   "a bare PAT (PID 0) opens the keyframe gate on its own, so "
-                   "forwarding starts mid-GOP even though no keyframe has been "
-                   "seen");
+            CHECK(!gate_opens_for(pat));
         }
 
-        // Same, buried after real null packets: still opens on the PAT.
+        // Same, buried behind an ordinary payload packet.
         {
             ServerConfig::setStripPadding(false);
             ServerConfig::setWaitKeyframe(true);
@@ -603,30 +625,87 @@ int main()
             append(p, make_ts(0x0100, 0x01)); // ordinary payload
             append(p, make_ts(0x0000, 0x02)); // PAT
             size_t len = p.size();
-            XCHECK(!pipe.process(p.data(), len),
-                   "the PAT-as-keyframe shortcut also fires when the PAT is "
-                   "not the first TS packet in the datagram");
+            CHECK(!pipe.process(p.data(), len));
+        }
+
+        // afc = 2 is an adaptation field with no payload at all. A start code
+        // pattern inside the stuffing is not video and must not be scanned.
+        {
+            std::vector<uint8_t> ts = make_ts(0x0100, FILL);
+            ts[3] = 0x20; // afc = 2
+            ts[4] = 10;   // adaptation_field_length
+            ts[5] = 0x00; // no random access indicator
+            ts[20] = 0x00;
+            ts[21] = 0x00;
+            ts[22] = 0x01;
+            ts[23] = 0x65; // H.264 IDR pattern, inside the stuffing
+            CHECK(!gate_opens_for(ts));
         }
 
         // Off-by-one at the tail of the TS payload: with afc=1 the scan window
-        // is data[0..183], but the loop guard `j + 4 < data_len` stops at
-        // j == 179, so a start code occupying the final four payload bytes is
-        // never examined and a real IDR there is missed.
+        // is data[0..183], so a start code occupying the final four payload
+        // bytes must still be examined.
         {
             std::vector<uint8_t> ts = make_ts(0x0100, FILL);
             ts[184] = 0x00;
             ts[185] = 0x00;
             ts[186] = 0x01;
             ts[187] = 0x65; // H.264 IDR
-            XCHECK(gate_opens_for(ts),
-                   "scan loop guard is `j + 4 < data_len` instead of "
-                   "`j + 3 < data_len`, so a start code in the last four bytes "
-                   "of a TS payload is skipped and the IDR is missed");
+            CHECK(gate_opens_for(ts));
+        }
+
+        // Same position, but an H.265 parameter set: its second header byte is
+        // past the end of the packet, so it cannot be confirmed and is ignored.
+        {
+            std::vector<uint8_t> ts = make_ts(0x0100, FILL);
+            ts[184] = 0x00;
+            ts[185] = 0x00;
+            ts[186] = 0x01;
+            ts[187] = 0x40; // H.265 VPS, second header byte missing
+            CHECK(!gate_opens_for(ts));
         }
 
         // Leave the shared config in a neutral state for anything that follows.
         ServerConfig::setWaitKeyframe(false);
         ServerConfig::setStripPadding(false);
+    }
+
+    // -----------------------------------------------------------------
+    SUITE("keyframe gate: bounded fallback");
+    {
+        // Dropping forever is worse than starting mid-GOP: a stream whose
+        // keyframes the scanner cannot see (unknown codec, scrambled payload)
+        // must still start playing after a bounded number of packets.
+        ServerConfig::setStripPadding(false);
+        ServerConfig::setWaitKeyframe(true);
+        RtpPipeline pipe;
+        pipe.reset();
+
+        std::vector<uint8_t> p = rtp_header();
+        append(p, make_ts(0x0100, 0x01)); // never a keyframe
+
+        uint32_t opened_at = 0;
+        for (uint32_t i = 1; i <= RtpPipeline::KEYFRAME_WAIT_LIMIT; ++i)
+        {
+            size_t len = p.size();
+            if (pipe.process(p.data(), len))
+            {
+                opened_at = i;
+                break;
+            }
+        }
+        CHECK_EQ(opened_at, RtpPipeline::KEYFRAME_WAIT_LIMIT);
+
+        // Once forced open it stays open.
+        size_t len2 = p.size();
+        CHECK(pipe.process(p.data(), len2));
+
+        // reset() re-arms both the gate and the fallback counter.
+        pipe.reset();
+        size_t len3 = p.size();
+        CHECK(!pipe.process(p.data(), len3));
+
+        ServerConfig::setWaitKeyframe(false);
     }
 
     return tst::summary();

--- a/test/unit/test_rtsp_parser.cpp
+++ b/test/unit/test_rtsp_parser.cpp
@@ -1,0 +1,603 @@
+// Unit tests for rtspParser (src/protocol/rtsp_parser.cpp).
+//
+// Scope: the pure parsing helpers -- status line, header extraction,
+// Content-Length, Session, Transport server_port/interleaved, RTSP URL split
+// and the SDP body parser.
+//
+// NOTE ON HOSTNAMES: rtspParser::parse_url falls back to DNSResolver for any
+// host that is not a numeric IPv4 literal. Every URL below therefore uses a
+// dotted-quad from the TEST-NET-1 documentation range (192.0.2.0/24) so the
+// tests never touch the network and never block on a resolver.
+
+#include "test_harness.h"
+
+#include "common/rtsp_ctx.h"
+#include "core/logger.h"
+#include "protocol/rtsp_parser.h"
+
+#include <map>
+#include <string>
+
+namespace
+{
+
+// The parser logs to stdout on some error paths; push the threshold above
+// every defined level so the harness output stays readable.
+void silence_logger()
+{
+    Logger::setLogLevel(static_cast<LogLevel>(100));
+}
+
+std::string attr_of(const Media &m, const std::string &key)
+{
+    auto it = m.attributes.find(key);
+    return it == m.attributes.end() ? std::string("<missing>") : it->second;
+}
+
+int bw_of(const std::map<std::string, int> &m, const std::string &key)
+{
+    auto it = m.find(key);
+    return it == m.end() ? -1 : it->second;
+}
+
+size_t sz(size_t v) { return v; }
+
+// ---------------------------------------------------------------- status line
+
+void test_parse_status_code()
+{
+    SUITE("parse_status_code");
+
+    CHECK_EQ(rtspParser::parse_status_code("RTSP/1.0 200 OK\r\n"), 200);
+    CHECK_EQ(rtspParser::parse_status_code("RTSP/1.0 401 Unauthorized\r\n"), 401);
+    CHECK_EQ(rtspParser::parse_status_code("RTSP/1.0 302 Found\r\nLocation: x\r\n\r\n"), 302);
+    // extra whitespace between version and code is tolerated by scanf
+    CHECK_EQ(rtspParser::parse_status_code("RTSP/1.0   503 Service Unavailable"), 503);
+    // no reason phrase
+    CHECK_EQ(rtspParser::parse_status_code("RTSP/1.0 454"), 454);
+
+    // malformed / non-RTSP inputs must yield the -1 sentinel, never a stale or
+    // uninitialised code.
+    CHECK_EQ(rtspParser::parse_status_code(""), -1);
+    CHECK_EQ(rtspParser::parse_status_code("HTTP/1.1 200 OK\r\n"), -1);
+    CHECK_EQ(rtspParser::parse_status_code("RTSP/1.0"), -1);
+    CHECK_EQ(rtspParser::parse_status_code("RTSP/1.0 OK 200"), -1);
+    CHECK_EQ(rtspParser::parse_status_code("OPTIONS rtsp://192.0.2.10/ RTSP/1.0"), -1);
+    // status line is case sensitive per RFC 2326 -- lowercase is not a response
+    CHECK_EQ(rtspParser::parse_status_code("rtsp/1.0 200 OK"), -1);
+}
+
+// ------------------------------------------------------------ header lookup
+
+void test_extract_header_value()
+{
+    SUITE("extract_header_value");
+
+    const std::string resp =
+        "RTSP/1.0 200 OK\r\n"
+        "CSeq: 3\r\n"
+        "Content-Type: application/sdp\r\n"
+        "Session: 12345678;timeout=60\r\n"
+        "Content-Length: 42\r\n"
+        "\r\n";
+
+    CHECK_EQ(rtspParser::extract_header_value(resp, "CSeq"), std::string("3"));
+    CHECK_EQ(rtspParser::extract_header_value(resp, "Content-Type"),
+             std::string("application/sdp"));
+    CHECK_EQ(rtspParser::extract_header_value(resp, "Session"),
+             std::string("12345678;timeout=60"));
+
+    // header names are case insensitive in both directions
+    CHECK_EQ(rtspParser::extract_header_value(resp, "session"),
+             std::string("12345678;timeout=60"));
+    CHECK_EQ(rtspParser::extract_header_value(resp, "CONTENT-LENGTH"), std::string("42"));
+    const std::string odd_case =
+        "RTSP/1.0 200 OK\r\ncSeQ: 7\r\nsession: abc\r\n\r\n";
+    CHECK_EQ(rtspParser::extract_header_value(odd_case, "CSeq"), std::string("7"));
+    CHECK_EQ(rtspParser::extract_header_value(odd_case, "Session"), std::string("abc"));
+
+    // absent header yields the empty string
+    CHECK_EQ(rtspParser::extract_header_value(resp, "Transport"), std::string(""));
+
+    // leading spaces/tabs after the colon are stripped, the value is not
+    // otherwise altered.
+    const std::string padded = "RTSP/1.0 200 OK\r\nCSeq:\t \t9\r\n\r\n";
+    CHECK_EQ(rtspParser::extract_header_value(padded, "CSeq"), std::string("9"));
+
+    // header on the very first line of the buffer is still found
+    const std::string first_line = "Session: only\r\nCSeq: 1\r\n\r\n";
+    CHECK_EQ(rtspParser::extract_header_value(first_line, "Session"), std::string("only"));
+
+    // last header without a terminating CRLF returns the tail
+    const std::string unterminated = "RTSP/1.0 200 OK\r\nCSeq: 12";
+    CHECK_EQ(rtspParser::extract_header_value(unterminated, "CSeq"), std::string("12"));
+
+    // empty value
+    const std::string empty_val = "RTSP/1.0 200 OK\r\nSession:\r\n\r\n";
+    CHECK_EQ(rtspParser::extract_header_value(empty_val, "Session"), std::string(""));
+
+    SUITE("extract_header_value / line anchoring");
+
+    // A *different* header whose name merely ends with the requested name must
+    // not satisfy the lookup.
+    const std::string x_only = "RTSP/1.0 200 OK\r\nX-Session: nope\r\nCSeq: 1\r\n\r\n";
+    CHECK_EQ(rtspParser::extract_header_value(x_only, "Session"), std::string(""));
+
+    // ... and when both exist, the real one wins regardless of order.
+    const std::string x_first =
+        "RTSP/1.0 200 OK\r\nX-Session: nope\r\nSession: real\r\n\r\n";
+    CHECK_EQ(rtspParser::extract_header_value(x_first, "Session"), std::string("real"));
+    const std::string x_last =
+        "RTSP/1.0 200 OK\r\nSession: real\r\nX-Session: nope\r\n\r\n";
+    CHECK_EQ(rtspParser::extract_header_value(x_last, "Session"), std::string("real"));
+
+    // "session:" appearing inside another header's *value* must not match.
+    const std::string in_value =
+        "RTSP/1.0 200 OK\r\nX-Debug: session:bogus\r\nCSeq: 1\r\n\r\n";
+    CHECK_EQ(rtspParser::extract_header_value(in_value, "Session"), std::string(""));
+    const std::string in_value_then_real =
+        "RTSP/1.0 200 OK\r\nX-Debug: session:bogus\r\nSession: real\r\n\r\n";
+    CHECK_EQ(rtspParser::extract_header_value(in_value_then_real, "Session"),
+             std::string("real"));
+
+    // ... including inside the body that follows the blank line.
+    const std::string in_body =
+        "RTSP/1.0 200 OK\r\nContent-Length: 20\r\n\r\na=tool: session:xyz\r\n";
+    CHECK_EQ(rtspParser::extract_header_value(in_body, "Session"), std::string(""));
+
+    // RTSP mandates CRLF; a bare-LF message is not a valid header block and
+    // must not be mined for values.
+    const std::string lf_only = "RTSP/1.0 200 OK\nSession: 42\n\n";
+    CHECK_EQ(rtspParser::extract_header_value(lf_only, "Session"), std::string(""));
+}
+
+// ------------------------------------------------------------ Content-Length
+
+void test_get_content_length()
+{
+    SUITE("get_content_length");
+
+    CHECK_EQ(rtspParser::get_content_length(
+                 "RTSP/1.0 200 OK\r\nContent-Length: 314\r\n\r\n"),
+             314);
+    CHECK_EQ(rtspParser::get_content_length(
+                 "RTSP/1.0 200 OK\r\ncontent-length: 0\r\n\r\n"),
+             0);
+    // trailing horizontal whitespace before the CRLF is tolerated
+    CHECK_EQ(rtspParser::get_content_length(
+                 "RTSP/1.0 200 OK\r\nContent-Length: 7 \t\r\n\r\n"),
+             7);
+    // no header at all means no body
+    CHECK_EQ(rtspParser::get_content_length("RTSP/1.0 200 OK\r\nCSeq: 1\r\n\r\n"), 0);
+
+    // malformed values must be rejected with -1, not silently truncated
+    CHECK_EQ(rtspParser::get_content_length(
+                 "RTSP/1.0 200 OK\r\nContent-Length: 123abc\r\n\r\n"),
+             -1);
+    CHECK_EQ(rtspParser::get_content_length(
+                 "RTSP/1.0 200 OK\r\nContent-Length: 12 3\r\n\r\n"),
+             -1);
+    CHECK_EQ(rtspParser::get_content_length(
+                 "RTSP/1.0 200 OK\r\nContent-Length: abc\r\n\r\n"),
+             -1);
+    CHECK_EQ(rtspParser::get_content_length(
+                 "RTSP/1.0 200 OK\r\nContent-Length: 0x10\r\n\r\n"),
+             -1);
+    // negative
+    CHECK_EQ(rtspParser::get_content_length(
+                 "RTSP/1.0 200 OK\r\nContent-Length: -1\r\n\r\n"),
+             -1);
+    // above INT_MAX but representable in long long
+    CHECK_EQ(rtspParser::get_content_length(
+                 "RTSP/1.0 200 OK\r\nContent-Length: 2147483648\r\n\r\n"),
+             -1);
+    // beyond long long entirely (stoll throws out_of_range)
+    CHECK_EQ(rtspParser::get_content_length(
+                 "RTSP/1.0 200 OK\r\nContent-Length: 99999999999999999999999\r\n\r\n"),
+             -1);
+    // INT_MAX itself is still accepted
+    CHECK_EQ(rtspParser::get_content_length(
+                 "RTSP/1.0 200 OK\r\nContent-Length: 2147483647\r\n\r\n"),
+             2147483647);
+}
+
+// ------------------------------------------------------------------- Session
+
+void test_parse_session_id()
+{
+    SUITE("parse_session_id");
+
+    rtspCtx ctx{};
+    CHECK_EQ(rtspParser::parse_session_id(
+                 "RTSP/1.0 200 OK\r\nCSeq: 2\r\nSession: 12345678\r\n\r\n", ctx),
+             0);
+    CHECK_EQ(ctx.session_id, std::string("12345678"));
+
+    // the ;timeout= parameter must be stripped from the id
+    rtspCtx ctx2{};
+    CHECK_EQ(rtspParser::parse_session_id(
+                 "RTSP/1.0 200 OK\r\nSession: A1B2C3D4;timeout=60\r\n\r\n", ctx2),
+             0);
+    CHECK_EQ(ctx2.session_id, std::string("A1B2C3D4"));
+
+    // multiple parameters
+    rtspCtx ctx3{};
+    CHECK_EQ(rtspParser::parse_session_id(
+                 "RTSP/1.0 200 OK\r\nSession: 99;timeout=30;foo=bar\r\n\r\n", ctx3),
+             0);
+    CHECK_EQ(ctx3.session_id, std::string("99"));
+
+    // missing header -> failure, ctx untouched
+    rtspCtx ctx4{};
+    ctx4.session_id = "previous";
+    CHECK_EQ(rtspParser::parse_session_id("RTSP/1.0 200 OK\r\nCSeq: 1\r\n\r\n", ctx4), -1);
+    CHECK_EQ(ctx4.session_id, std::string("previous"));
+
+    // present but empty -> failure
+    rtspCtx ctx5{};
+    CHECK_EQ(rtspParser::parse_session_id("RTSP/1.0 200 OK\r\nSession:\r\n\r\n", ctx5), -1);
+
+    // an X-Session header must not be mistaken for the session id
+    rtspCtx ctx6{};
+    CHECK_EQ(rtspParser::parse_session_id(
+                 "RTSP/1.0 200 OK\r\nX-Session: decoy\r\n\r\n", ctx6),
+             -1);
+}
+
+// ----------------------------------------------------------------- Transport
+
+void test_parse_server_ports()
+{
+    SUITE("parse_server_ports / UDP");
+
+    rtspCtx ctx{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\n"
+                 "Transport: RTP/AVP;unicast;client_port=5000-5001;server_port=6970-6971\r\n"
+                 "Session: 1\r\n\r\n",
+                 ctx),
+             0);
+    CHECK_EQ(ctx.server_rtp_port, 6970);
+    CHECK_EQ(ctx.server_rtcp_port, 6971);
+
+    // trailing parameters after the range must not confuse the second stoi
+    rtspCtx ctx2{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\n"
+                 "Transport: RTP/AVP;unicast;server_port=6970-6971;ssrc=1234ABCD\r\n\r\n",
+                 ctx2),
+             0);
+    CHECK_EQ(ctx2.server_rtp_port, 6970);
+    CHECK_EQ(ctx2.server_rtcp_port, 6971);
+
+    // out-of-range port numbers are rejected
+    rtspCtx ctx3{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\nTransport: RTP/AVP;server_port=0-1\r\n\r\n", ctx3),
+             -1);
+    rtspCtx ctx4{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\nTransport: RTP/AVP;server_port=70000-70001\r\n\r\n",
+                 ctx4),
+             -1);
+
+    // no Transport header at all
+    rtspCtx ctx5{};
+    CHECK_EQ(rtspParser::parse_server_ports("RTSP/1.0 200 OK\r\nCSeq: 1\r\n\r\n", ctx5), -1);
+
+    // Transport present but carries neither server_port nor interleaved
+    rtspCtx ctx6{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\nTransport: RTP/AVP;unicast;client_port=5000-5001\r\n\r\n",
+                 ctx6),
+             -1);
+
+    SUITE("parse_server_ports / TCP interleaved");
+
+    rtspCtx tcp{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\n"
+                 "Transport: RTP/AVP/TCP;unicast;interleaved=0-1\r\n\r\n",
+                 tcp),
+             0);
+    CHECK_EQ(tcp.server_rtp_port, 0);
+    CHECK_EQ(tcp.server_rtcp_port, 1);
+
+    rtspCtx tcp2{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\n"
+                 "Transport: RTP/AVP/TCP;unicast;interleaved=2-3;ssrc=DEADBEEF\r\n\r\n",
+                 tcp2),
+             0);
+    CHECK_EQ(tcp2.server_rtp_port, 2);
+    CHECK_EQ(tcp2.server_rtcp_port, 3);
+
+    // channel numbers are single bytes
+    rtspCtx tcp3{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\nTransport: RTP/AVP/TCP;interleaved=256-257\r\n\r\n",
+                 tcp3),
+             -1);
+
+    // server_port takes precedence when both are present
+    rtspCtx both{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\n"
+                 "Transport: RTP/AVP;server_port=6970-6971;interleaved=4-5\r\n\r\n",
+                 both),
+             0);
+    CHECK_EQ(both.server_rtp_port, 6970);
+
+    SUITE("parse_server_ports / dash scanned across whole Transport value");
+
+    // The '-' that separates the RTP and RTCP ports is searched across the
+    // entire remainder of the Transport value instead of only within the
+    // server_port parameter (up to the next ';'). With a single-port
+    // server_port and a later quoted parameter the second stoi throws, so the
+    // (correct) -1 is reached by accident.
+    rtspCtx w1{};
+    w1.server_rtp_port = 1111;
+    w1.server_rtcp_port = 2222;
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\n"
+                 "Transport: RTP/AVP;unicast;server_port=6970;mode=\"play-record\"\r\n\r\n",
+                 w1),
+             -1);
+    CHECK_EQ(w1.server_rtp_port, 1111);
+    CHECK_EQ(w1.server_rtcp_port, 2222);
+
+    // Same weakness, now with an observable wrong answer: the dash of a later
+    // numeric parameter is used, so a malformed (single-port) server_port is
+    // accepted and the RTCP port is taken from client_port.
+    rtspCtx w2{};
+    const std::string cross =
+        "RTSP/1.0 200 OK\r\n"
+        "Transport: RTP/AVP;unicast;server_port=6970;client_port=9000-9001\r\n\r\n";
+    XCHECK_EQ(rtspParser::parse_server_ports(cross, w2), -1,
+              "dash is searched across the whole Transport value, so a single-port "
+              "server_port pairs with a dash from a later parameter");
+    XCHECK_EQ(static_cast<int>(w2.server_rtcp_port), 0,
+              "RTCP port harvested from the client_port parameter (9001)");
+
+    // The interleaved branch has the identical weakness.
+    rtspCtx w3{};
+    const std::string cross_tcp =
+        "RTSP/1.0 200 OK\r\n"
+        "Transport: RTP/AVP/TCP;unicast;interleaved=0;ssrc=1;x=7-9\r\n\r\n";
+    XCHECK_EQ(rtspParser::parse_server_ports(cross_tcp, w3), -1,
+              "interleaved= without a range still matches a dash from an unrelated "
+              "parameter later in the Transport value");
+}
+
+// ---------------------------------------------------------------------- URL
+
+void test_parse_url()
+{
+    SUITE("parse_url / literal IPv4");
+
+    rtspCtx a{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.10:8554/live/ch0", a), 0);
+    CHECK_EQ(a.server_ip, std::string("192.0.2.10"));
+    CHECK_EQ(a.server_rtsp_port, 8554);
+    CHECK_EQ(a.path, std::string("/live/ch0"));
+    CHECK_EQ(a.rtsp_url, std::string("rtsp://192.0.2.10:8554/live/ch0"));
+
+    // default RTSP port when none is given
+    rtspCtx b{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.20/stream1", b), 0);
+    CHECK_EQ(b.server_ip, std::string("192.0.2.20"));
+    CHECK_EQ(b.server_rtsp_port, 554);
+    CHECK_EQ(b.path, std::string("/stream1"));
+
+    // no path at all -> "/"
+    rtspCtx c{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.30:5540", c), 0);
+    CHECK_EQ(c.server_rtsp_port, 5540);
+    CHECK_EQ(c.path, std::string("/"));
+
+    // bare trailing slash
+    rtspCtx d{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.30/", d), 0);
+    CHECK_EQ(d.path, std::string("/"));
+
+    // query string stays part of the path
+    rtspCtx e{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.40:554/cam?chan=1&sub=0", e), 0);
+    CHECK_EQ(e.path, std::string("/cam?chan=1&sub=0"));
+
+    SUITE("parse_url / rejections");
+
+    rtspCtx f{};
+    CHECK_EQ(rtspParser::parse_url("http://192.0.2.10/x", f), -1);
+    // the (cleaned) input is recorded even on the failure path
+    CHECK_EQ(f.rtsp_url, std::string("http://192.0.2.10/x"));
+
+    rtspCtx g{};
+    CHECK_EQ(rtspParser::parse_url("", g), -1);
+    rtspCtx h{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://", h), -1);
+    rtspCtx i{};
+    CHECK_EQ(rtspParser::parse_url("rtsp:///path", i), -1);
+    rtspCtx j{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.10:abc/x", j), -1);
+    rtspCtx k{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.10:8554x/x", k), -1);
+    rtspCtx l{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.10:0/x", l), -1);
+    rtspCtx m{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.10:99999/x", m), -1);
+
+    SUITE("parse_url / backslash and %5C stripping");
+
+    // Backslashes are removed outright (they are neither converted to '/' nor
+    // left in place), which is what keeps a CDN-mangled URL routable.
+    rtspCtx n{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.50:554/live\\/ch0", n), 0);
+    CHECK_EQ(n.path, std::string("/live/ch0"));
+    CHECK_EQ(n.rtsp_url, std::string("rtsp://192.0.2.50:554/live/ch0"));
+
+    rtspCtx o{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.50/live%5C/ch1", o), 0);
+    CHECK_EQ(o.path, std::string("/live/ch1"));
+
+    // lowercase escape is handled too
+    rtspCtx p{};
+    CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.50/live%5c/ch2", p), 0);
+    CHECK_EQ(p.path, std::string("/live/ch2"));
+
+    // several of them, mixed
+    rtspCtx q{};
+    CHECK_EQ(rtspParser::parse_url("rtsp:%5C/%5c/192.0.2.60:554/a\\b%5Cc", q), 0);
+    CHECK_EQ(q.server_ip, std::string("192.0.2.60"));
+    CHECK_EQ(q.path, std::string("/abc"));
+
+    SUITE("parse_url / IPv6 literal");
+
+    // A bracketed IPv6 literal is rejected: the first ':' inside the brackets
+    // is taken as the port separator. Documented, not fixed here.
+    rtspCtx r{};
+    XCHECK_EQ(rtspParser::parse_url("rtsp://[2001:db8::1]:554/live", r), 0,
+              "bracketed IPv6 literals are not understood (first ':' read as the "
+              "port separator)");
+}
+
+// ---------------------------------------------------------------------- SDP
+
+void test_sdp()
+{
+    SUITE("SDP::parseSDP / session level");
+
+    const std::string sdp =
+        "v=0\r\n"
+        "o=- 2890844526 1 IN IP4 192.0.2.10\r\n"
+        "s=Media Presentation\r\n"
+        "t=0 0\r\n"
+        "a=range:npt=0-\r\n"
+        "b=AS:4096\r\n"
+        "m=video 0 RTP/AVP 96\r\n"
+        "b=AS:2048\r\n"
+        "a=rtpmap:96 H264/90000\r\n"
+        "a=fmtp:96 packetization-mode=1\r\n"
+        "a=control:trackID=1\r\n"
+        "a=recvonly\r\n"
+        "m=audio 0 RTP/AVP 97 98\r\n"
+        "a=rtpmap:97 MPEG4-GENERIC/16000\r\n"
+        "a=control:trackID=2\r\n";
+
+    rtspCtx ctx{};
+    rtspParser::SDP::parseSDP(sdp, ctx);
+
+    CHECK_EQ(ctx.sdp.version, std::string("0"));
+    CHECK_EQ(ctx.sdp.origin, std::string("- 2890844526 1 IN IP4 192.0.2.10"));
+    CHECK_EQ(ctx.sdp.session_name, std::string("Media Presentation"));
+    CHECK_EQ(ctx.sdp.time, std::string("0 0"));
+
+    SUITE("SDP::parseSDP / m= lines");
+
+    CHECK_EQ(sz(ctx.sdp.media_streams.size()), sz(2));
+    if (ctx.sdp.media_streams.size() == 2)
+    {
+        const Media &v = ctx.sdp.media_streams[0];
+        const Media &a = ctx.sdp.media_streams[1];
+
+        CHECK_EQ(v.type, std::string("video"));
+        CHECK_EQ(v.port, 0);
+        CHECK_EQ(v.protocol, std::string("RTP/AVP"));
+        CHECK_EQ(sz(v.formats.size()), sz(1));
+        CHECK_EQ(v.formats.front(), std::string("96"));
+
+        CHECK_EQ(a.type, std::string("audio"));
+        CHECK_EQ(a.protocol, std::string("RTP/AVP"));
+        CHECK_EQ(sz(a.formats.size()), sz(2));
+        if (a.formats.size() == 2)
+        {
+            CHECK_EQ(a.formats[0], std::string("97"));
+            CHECK_EQ(a.formats[1], std::string("98"));
+        }
+
+        SUITE("SDP::parseSDP / a= binds to most recent m=");
+
+        CHECK_EQ(attr_of(v, "rtpmap"), std::string("96 H264/90000"));
+        CHECK_EQ(attr_of(v, "fmtp"), std::string("96 packetization-mode=1"));
+        CHECK_EQ(attr_of(v, "control"), std::string("trackID=1"));
+        CHECK_EQ(v.trackID, std::string("trackID=1"));
+
+        CHECK_EQ(attr_of(a, "rtpmap"), std::string("97 MPEG4-GENERIC/16000"));
+        CHECK_EQ(attr_of(a, "control"), std::string("trackID=2"));
+        CHECK_EQ(a.trackID, std::string("trackID=2"));
+
+        // the audio section must not inherit the video attributes
+        CHECK_EQ(sz(a.attributes.count("fmtp")), sz(0));
+
+        // a session-level a= that appears before any m= is dropped: sdpCtx has
+        // nowhere to keep it, and it must not leak into the first media section.
+        CHECK_EQ(sz(v.attributes.count("range")), sz(0));
+        CHECK_EQ(sz(a.attributes.count("range")), sz(0));
+
+        // property attributes (no ':') are silently discarded
+        XCHECK_EQ(sz(v.attributes.count("recvonly")), sz(1),
+                  "flag attributes such as a=recvonly are dropped because "
+                  "parseAttribute requires a ':' separator");
+
+        SUITE("SDP::parseSDP / b= bandwidth");
+
+        // every b= line lands in the session map...
+        CHECK_EQ(sz(ctx.sdp.session_bandwidth.count("AS")), sz(1));
+        // ... including media-level ones, which overwrite the session value.
+        XCHECK_EQ(bw_of(ctx.sdp.session_bandwidth, "AS"), 4096,
+                  "media-level b= is written to sdpCtx.session_bandwidth and "
+                  "clobbers the session-level value");
+        XCHECK_EQ(sz(v.bandwidth.count("AS")), sz(1),
+                  "Media::bandwidth is never populated; media-level b= is not "
+                  "bound to its m= section");
+    }
+
+    SUITE("SDP::parseSDP / robustness");
+
+    // Bare-LF SDP (common in the wild) parses fine; the trailing \r of CRLF
+    // bodies is trimmed rather than kept in the value.
+    rtspCtx lf{};
+    rtspParser::SDP::parseSDP("v=0\ns=lf body\nm=video 0 RTP/AVP 96\n", lf);
+    CHECK_EQ(lf.sdp.session_name, std::string("lf body"));
+    CHECK_EQ(sz(lf.sdp.media_streams.size()), sz(1));
+
+    // A non-numeric media port drops the whole m= section, and the a= lines
+    // that follow are discarded instead of crashing or attaching elsewhere.
+    rtspCtx bad{};
+    rtspParser::SDP::parseSDP("v=0\r\nm=video xyz RTP/AVP 96\r\na=control:trackID=1\r\n", bad);
+    CHECK_EQ(sz(bad.sdp.media_streams.size()), sz(0));
+
+    // A malformed b= value is ignored rather than stored as 0.
+    rtspCtx badbw{};
+    rtspParser::SDP::parseSDP("v=0\r\nb=AS:notanumber\r\n", badbw);
+    CHECK_EQ(sz(badbw.sdp.session_bandwidth.count("AS")), sz(0));
+
+    // Empty body is a no-op.
+    rtspCtx empty{};
+    rtspParser::SDP::parseSDP("", empty);
+    CHECK_EQ(sz(empty.sdp.media_streams.size()), sz(0));
+    CHECK_EQ(empty.sdp.version, std::string(""));
+
+    // Blank lines and unknown line types are skipped.
+    rtspCtx mixed{};
+    rtspParser::SDP::parseSDP("v=0\r\n\r\nz=0 0\r\nc=IN IP4 0.0.0.0\r\ns=ok\r\n", mixed);
+    CHECK_EQ(mixed.sdp.version, std::string("0"));
+    CHECK_EQ(mixed.sdp.session_name, std::string("ok"));
+}
+
+} // namespace
+
+int main()
+{
+    silence_logger();
+
+    test_parse_status_code();
+    test_extract_header_value();
+    test_get_content_length();
+    test_parse_session_id();
+    test_parse_server_ports();
+    test_parse_url();
+    test_sdp();
+
+    return tst::summary();
+}

--- a/test/unit/test_rtsp_parser.cpp
+++ b/test/unit/test_rtsp_parser.cpp
@@ -151,6 +151,28 @@ void test_extract_header_value()
     CHECK_EQ(rtspParser::extract_header_value(lf_only, "Session"), std::string(""));
 }
 
+void test_replace_request_uri()
+{
+    SUITE("replace_request_uri");
+
+    const std::string request =
+        "DESCRIBE rtsp://proxy.example/old/path?old=1 RTSP/1.0\r\n"
+        "CSeq: 7\r\n"
+        "Accept: application/sdp\r\n\r\n";
+    const std::string location =
+        "rtsp://124.132.240.33:554/live/ch.sdp?playtype=1&time=20260730055417+08"
+        "&profilecode=&AuthInfo=XpUHKW8KQXs8yP0uyna3%2Bu8XDxkg%3D%3D";
+
+    CHECK_EQ(rtspParser::replace_request_uri(request, location),
+             "DESCRIBE " + location + " RTSP/1.0\r\n"
+             "CSeq: 7\r\n"
+             "Accept: application/sdp\r\n\r\n");
+
+    // Malformed/incomplete messages are left untouched.
+    CHECK_EQ(rtspParser::replace_request_uri("DESCRIBE /x", location),
+             std::string("DESCRIBE /x"));
+}
+
 // ------------------------------------------------------------ Content-Length
 
 void test_get_content_length()
@@ -646,6 +668,7 @@ int main()
 
     test_parse_status_code();
     test_extract_header_value();
+    test_replace_request_uri();
     test_get_content_length();
     test_parse_session_id();
     test_parse_server_ports();

--- a/test/unit/test_rtsp_parser.cpp
+++ b/test/unit/test_rtsp_parser.cpp
@@ -328,13 +328,12 @@ void test_parse_server_ports()
              0);
     CHECK_EQ(both.server_rtp_port, 6970);
 
-    SUITE("parse_server_ports / dash scanned across whole Transport value");
+    SUITE("parse_server_ports / dash is bounded to its own parameter");
 
-    // The '-' that separates the RTP and RTCP ports is searched across the
-    // entire remainder of the Transport value instead of only within the
-    // server_port parameter (up to the next ';'). With a single-port
-    // server_port and a later quoted parameter the second stoi throws, so the
-    // (correct) -1 is reached by accident.
+    // The '-' that separates the RTP and RTCP ports is only looked for inside
+    // the server_port parameter (up to the next ';'), so a dash living in a
+    // later parameter can neither be used as the separator nor make the parse
+    // throw.
     rtspCtx w1{};
     w1.server_rtp_port = 1111;
     w1.server_rtcp_port = 2222;
@@ -346,27 +345,54 @@ void test_parse_server_ports()
     CHECK_EQ(w1.server_rtp_port, 1111);
     CHECK_EQ(w1.server_rtcp_port, 2222);
 
-    // Same weakness, now with an observable wrong answer: the dash of a later
-    // numeric parameter is used, so a malformed (single-port) server_port is
-    // accepted and the RTCP port is taken from client_port.
+    // A single-port server_port must not pair with the dash of a later
+    // parameter, and must leave the context untouched.
     rtspCtx w2{};
     const std::string cross =
         "RTSP/1.0 200 OK\r\n"
         "Transport: RTP/AVP;unicast;server_port=6970;client_port=9000-9001\r\n\r\n";
-    XCHECK_EQ(rtspParser::parse_server_ports(cross, w2), -1,
-              "dash is searched across the whole Transport value, so a single-port "
-              "server_port pairs with a dash from a later parameter");
-    XCHECK_EQ(static_cast<int>(w2.server_rtcp_port), 0,
-              "RTCP port harvested from the client_port parameter (9001)");
+    CHECK_EQ(rtspParser::parse_server_ports(cross, w2), -1);
+    CHECK_EQ(static_cast<int>(w2.server_rtp_port), 0);
+    CHECK_EQ(static_cast<int>(w2.server_rtcp_port), 0);
 
-    // The interleaved branch has the identical weakness.
+    // The interleaved branch is bounded the same way.
     rtspCtx w3{};
     const std::string cross_tcp =
         "RTSP/1.0 200 OK\r\n"
         "Transport: RTP/AVP/TCP;unicast;interleaved=0;ssrc=1;x=7-9\r\n\r\n";
-    XCHECK_EQ(rtspParser::parse_server_ports(cross_tcp, w3), -1,
-              "interleaved= without a range still matches a dash from an unrelated "
-              "parameter later in the Transport value");
+    CHECK_EQ(rtspParser::parse_server_ports(cross_tcp, w3), -1);
+    CHECK_EQ(static_cast<int>(w3.server_rtcp_port), 0);
+
+    // mode="play-record" before the range must not be mistaken for it either.
+    rtspCtx w4{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\n"
+                 "Transport: RTP/AVP;unicast;mode=\"play-record\";server_port=6970-6971\r\n\r\n",
+                 w4),
+             0);
+    CHECK_EQ(w4.server_rtp_port, 6970);
+    CHECK_EQ(w4.server_rtcp_port, 6971);
+
+    // Junk inside the parameter is rejected instead of being truncated away.
+    rtspCtx w5{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\nTransport: RTP/AVP;server_port=6970-69x1\r\n\r\n", w5),
+             -1);
+    rtspCtx w6{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\nTransport: RTP/AVP;server_port=-6971\r\n\r\n", w6),
+             -1);
+    rtspCtx w7{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\nTransport: RTP/AVP/TCP;interleaved=0-1x\r\n\r\n", w7),
+             -1);
+
+    // Padding around the numbers is still tolerated.
+    rtspCtx w8{};
+    CHECK_EQ(rtspParser::parse_server_ports(
+                 "RTSP/1.0 200 OK\r\nTransport: RTP/AVP;server_port=6970-6971 \r\n\r\n", w8),
+             0);
+    CHECK_EQ(w8.server_rtcp_port, 6971);
 }
 
 // ---------------------------------------------------------------------- URL
@@ -534,10 +560,9 @@ void test_sdp()
         CHECK_EQ(sz(v.attributes.count("range")), sz(0));
         CHECK_EQ(sz(a.attributes.count("range")), sz(0));
 
-        // property attributes (no ':') are silently discarded
-        XCHECK_EQ(sz(v.attributes.count("recvonly")), sz(1),
-                  "flag attributes such as a=recvonly are dropped because "
-                  "parseAttribute requires a ':' separator");
+        // property attributes (no ':') are kept with an empty value
+        CHECK_EQ(sz(v.attributes.count("recvonly")), sz(1));
+        CHECK_EQ(attr_of(v, "recvonly"), std::string(""));
 
         SUITE("SDP::parseSDP / b= bandwidth");
 
@@ -550,6 +575,34 @@ void test_sdp()
         XCHECK_EQ(sz(v.bandwidth.count("AS")), sz(1),
                   "Media::bandwidth is never populated; media-level b= is not "
                   "bound to its m= section");
+    }
+
+    SUITE("SDP::parseSDP / property attributes");
+
+    // The other common RFC 4566 flag attributes, and a value attribute whose
+    // value itself contains colons, all land in the map.
+    rtspCtx flags{};
+    rtspParser::SDP::parseSDP(
+        "v=0\r\n"
+        "m=video 0 RTP/AVP 96\r\n"
+        "a=sendonly\r\n"
+        "a=rtcp-mux\r\n"
+        "a=control:rtsp://192.0.2.10:554/live/trackID=1\r\n"
+        "a=\r\n",
+        flags);
+    CHECK_EQ(sz(flags.sdp.media_streams.size()), sz(1));
+    if (flags.sdp.media_streams.size() == 1)
+    {
+        const Media &f = flags.sdp.media_streams[0];
+        CHECK_EQ(attr_of(f, "sendonly"), std::string(""));
+        CHECK_EQ(attr_of(f, "rtcp-mux"), std::string(""));
+        // only the first ':' separates key from value
+        CHECK_EQ(attr_of(f, "control"),
+                 std::string("rtsp://192.0.2.10:554/live/trackID=1"));
+        CHECK_EQ(f.trackID, std::string("rtsp://192.0.2.10:554/live/trackID=1"));
+        // a bare "a=" has no key and is not stored
+        CHECK_EQ(sz(f.attributes.count("")), sz(0));
+        CHECK_EQ(sz(f.attributes.size()), sz(3));
     }
 
     SUITE("SDP::parseSDP / robustness");

--- a/test/unit/test_server_config.cpp
+++ b/test/unit/test_server_config.cpp
@@ -1,0 +1,571 @@
+// Unit tests for ServerConfig -- config-file half only.
+//
+// parseCommandLine() is deliberately NOT exercised: it drives getopt_long over
+// the global `optind`, which would collide with the test runner's own argv and
+// can call exit(0) on `-k`.  Everything here goes through loadFromFile().
+//
+// NO NETWORK: every host-shaped value below is a literal dotted quad from the
+// TEST-NET-1 block (192.0.2.0/24).  ServerConfig::setStunHost only stores the
+// string, but keeping the rule everywhere means a future refactor that starts
+// resolving it cannot silently make this suite hang.
+//
+// ServerConfig is entirely static global state, so each group sets the fields
+// it observes before asserting on them; the file is order-independent.
+
+#include "test_harness.h"
+
+#include "core/server_config.h"
+#include "core/logger.h"
+#include "utils/url_rewriter.h"
+#include "3rd/json.hpp"
+
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// temp-dir plumbing
+// ---------------------------------------------------------------------------
+
+static std::string g_dir;
+static std::vector<std::string> g_files;
+
+static bool make_temp_dir()
+{
+    const char *base = std::getenv("TMPDIR");
+    std::string tmpl = (base && *base ? std::string(base) : std::string("/tmp"));
+    if (tmpl.back() != '/')
+        tmpl += '/';
+    tmpl += "rtsproxy_cfg_XXXXXX";
+
+    std::vector<char> buf(tmpl.begin(), tmpl.end());
+    buf.push_back('\0');
+    char *made = mkdtemp(buf.data());
+    if (!made)
+        return false;
+    g_dir = made;
+    return true;
+}
+
+// Writes `body` to <tempdir>/<name> and returns the absolute path.  Nothing is
+// ever written outside the directory mkdtemp handed us.
+static std::string write_cfg(const std::string &name, const std::string &body)
+{
+    std::string path = g_dir + "/" + name;
+    std::ofstream ofs(path, std::ios::trunc);
+    ofs << body;
+    ofs.close();
+    g_files.push_back(path);
+    return path;
+}
+
+static void cleanup_temp_dir()
+{
+    for (const auto &f : g_files)
+        ::unlink(f.c_str());
+    if (!g_dir.empty())
+        ::rmdir(g_dir.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Puts the static config back into its documented compiled-in default state so
+// a group can assert "unchanged" against known values.
+// ---------------------------------------------------------------------------
+
+static void reset_to_defaults()
+{
+    ServerConfig::setPort(8554);
+    ServerConfig::setNatEnabled(false);
+    ServerConfig::setNatMethod("stun");
+    ServerConfig::setBufferPoolCount(8192);
+    ServerConfig::setBufferPoolBlockSize(2048);
+    ServerConfig::setStunPort(19302);
+    ServerConfig::setStunHost("192.0.2.1"); // literal IP stand-in, never resolved
+    ServerConfig::setToken("");
+    ServerConfig::setHttpUpstreamInterface("");
+    ServerConfig::setMitmUpstreamInterface("");
+    ServerConfig::setListenInterface("");
+    ServerConfig::setLogFile("");
+    ServerConfig::setLogLines(10000);
+    ServerConfig::setStripPadding(false);
+    ServerConfig::setWaitKeyframe(false);
+    ServerConfig::setWatchdogEnabled(false);
+    ServerConfig::setDaemonEnabled(false);
+    ServerConfig::setBlacklist({});
+}
+
+// ---------------------------------------------------------------------------
+// Outcome of one loadFromFile() call, including anything that escaped it.
+// ---------------------------------------------------------------------------
+
+struct LoadOutcome
+{
+    // Tri-state, so "it threw" is never mistaken for "it returned false":
+    // "true" | "false" | "threw".
+    std::string outcome = "threw";
+    bool returned = false;
+    bool threw = false;
+    std::string kind;   // exception type that escaped, "" if none
+    int json_id = -1;   // nlohmann exception id, -1 if not an nlohmann exception
+};
+
+static LoadOutcome load(const std::string &path)
+{
+    LoadOutcome o;
+    try
+    {
+        o.returned = ServerConfig::loadFromFile(path);
+        o.outcome = o.returned ? "true" : "false";
+    }
+    catch (const nlohmann::json::type_error &e)
+    {
+        o.threw = true;
+        o.kind = "nlohmann::json::type_error";
+        o.json_id = e.id;
+    }
+    catch (const nlohmann::json::parse_error &e)
+    {
+        o.threw = true;
+        o.kind = "nlohmann::json::parse_error";
+        o.json_id = e.id;
+    }
+    catch (const nlohmann::json::exception &e)
+    {
+        o.threw = true;
+        o.kind = "nlohmann::json::exception";
+        o.json_id = e.id;
+    }
+    catch (const std::out_of_range &)
+    {
+        o.threw = true;
+        o.kind = "std::out_of_range";
+    }
+    catch (const std::invalid_argument &)
+    {
+        o.threw = true;
+        o.kind = "std::invalid_argument";
+    }
+    catch (const std::exception &)
+    {
+        o.threw = true;
+        o.kind = "std::exception";
+    }
+    return o;
+}
+
+// ---------------------------------------------------------------------------
+
+static void test_full_settings_block()
+{
+    SUITE("loadFromFile: a complete settings block reaches every getter");
+
+    reset_to_defaults();
+    Logger::setLogLevel(LogLevel::ERROR);
+
+    std::string path = write_cfg("full.json", R"({
+        "settings": {
+            "port": 9100,
+            "nat_method": "zte",
+            "enable_nat": true,
+            "buffer_pool_count": 1024,
+            "buffer_pool_block_size": 4096,
+            "auth_token": "tok-abc",
+            "log_file": "/var/log/rtsproxy-unit.log",
+            "log_lines": 555,
+            "log_level": "warn",
+            "strip_padding": true,
+            "wait_keyframe": true,
+            "watchdog": true,
+            "daemon": true,
+            "http_interface": "eth0",
+            "mitm_interface": "eth1",
+            "listen_interface": "lo",
+            "stun_host": "192.0.2.10",
+            "stun_port": 3478
+        }
+    })");
+
+    LoadOutcome o = load(path);
+    CHECK(!o.threw);
+    CHECK_EQ(o.returned, true);
+
+    CHECK_EQ(ServerConfig::getPort(), 9100);
+    CHECK_EQ(ServerConfig::getNatMethod(), std::string("zte"));
+    CHECK_EQ(ServerConfig::isNatEnabled(), true);
+    CHECK_EQ(ServerConfig::getBufferPoolCount(), 1024);
+    CHECK_EQ(ServerConfig::getBufferPoolBlockSize(), 4096);
+    CHECK_EQ(ServerConfig::getToken(), std::string("tok-abc"));
+    CHECK_EQ(ServerConfig::getLogFile(), std::string("/var/log/rtsproxy-unit.log"));
+    CHECK_EQ(ServerConfig::getLogLines(), static_cast<size_t>(555));
+    CHECK_EQ(ServerConfig::isStripPadding(), true);
+    CHECK_EQ(ServerConfig::isWaitKeyframe(), true);
+    CHECK_EQ(ServerConfig::isWatchdogEnabled(), true);
+    CHECK_EQ(ServerConfig::isDaemonEnabled(), true);
+    CHECK_EQ(ServerConfig::getHttpUpstreamInterface(), std::string("eth0"));
+    CHECK_EQ(ServerConfig::getMitmUpstreamInterface(), std::string("eth1"));
+    CHECK_EQ(ServerConfig::getListenInterface(), std::string("lo"));
+    CHECK_EQ(ServerConfig::getStunHost(), std::string("192.0.2.10"));
+    CHECK_EQ(ServerConfig::getStunPort(), 3478);
+
+    // "log_level" is routed into Logger, not into a ServerConfig getter.
+    CHECK_EQ(static_cast<int>(Logger::getLogLevel()), static_cast<int>(LogLevel::WARN));
+
+    // setLogFile() on ServerConfig only records the path; it must not have
+    // handed it to Logger (that is main()'s job), so no file was created.
+    std::ifstream probe("/var/log/rtsproxy-unit.log");
+    CHECK(!probe.is_open());
+
+    Logger::setLogLevel(LogLevel::ERROR);
+}
+
+static void test_partial_settings_leave_the_rest_alone()
+{
+    SUITE("loadFromFile: keys absent from settings keep their current value");
+
+    reset_to_defaults();
+    ServerConfig::setToken("preexisting");
+    ServerConfig::setListenInterface("br-lan");
+
+    std::string path = write_cfg("partial.json", R"({
+        "settings": { "port": 7001 }
+    })");
+
+    LoadOutcome o = load(path);
+    CHECK_EQ(o.returned, true);
+    CHECK_EQ(ServerConfig::getPort(), 7001);
+    CHECK_EQ(ServerConfig::getToken(), std::string("preexisting"));
+    CHECK_EQ(ServerConfig::getListenInterface(), std::string("br-lan"));
+    CHECK_EQ(ServerConfig::getBufferPoolCount(), 8192);
+
+    // An empty object is valid and is a no-op.
+    std::string empty = write_cfg("empty_obj.json", "{}");
+    LoadOutcome o2 = load(empty);
+    CHECK_EQ(o2.returned, true);
+    CHECK_EQ(ServerConfig::getPort(), 7001);
+
+    // "settings" present but not an object is ignored rather than fatal.
+    std::string notobj = write_cfg("settings_not_object.json", R"({"settings": 42})");
+    LoadOutcome o3 = load(notobj);
+    CHECK_EQ(o3.returned, true);
+    CHECK(!o3.threw);
+    CHECK_EQ(ServerConfig::getPort(), 7001);
+}
+
+static void test_comments_are_tolerated()
+{
+    SUITE("loadFromFile: JSON comments are ignored (ignore_comments=true)");
+
+    reset_to_defaults();
+
+    std::string path = write_cfg("commented.json", R"({
+        // a leading line comment
+        "settings": {
+            "port": 9200,           // trailing line comment
+            /* block comment */
+            "auth_token": "from-commented-file"
+        }
+        // trailing comment at the end of the object
+    })");
+
+    LoadOutcome o = load(path);
+    CHECK(!o.threw);
+    CHECK_EQ(o.returned, true);
+    CHECK_EQ(ServerConfig::getPort(), 9200);
+    CHECK_EQ(ServerConfig::getToken(), std::string("from-commented-file"));
+}
+
+static void test_blacklist()
+{
+    SUITE("loadFromFile: blacklist array reaches getBlacklist");
+
+    reset_to_defaults();
+    ServerConfig::setBlacklist({"seed.invalid"});
+
+    // Dotted quads only: BlacklistChecker resolves non-numeric hosts via DNS.
+    std::string path = write_cfg("blacklist.json", R"({
+        "blacklist": ["192.0.2.20", "192.0.2.21", "198.51.100.7"]
+    })");
+
+    LoadOutcome o = load(path);
+    CHECK_EQ(o.returned, true);
+    CHECK_EQ(ServerConfig::getBlacklist().size(), static_cast<size_t>(3));
+    CHECK_EQ(ServerConfig::getBlacklist()[0], std::string("192.0.2.20"));
+    CHECK_EQ(ServerConfig::getBlacklist()[1], std::string("192.0.2.21"));
+    CHECK_EQ(ServerConfig::getBlacklist()[2], std::string("198.51.100.7"));
+
+    // Non-string entries are skipped, not fatal.
+    std::string mixed = write_cfg("blacklist_mixed.json", R"({
+        "blacklist": ["192.0.2.30", 42, null, {"host": "x"}, "192.0.2.31"]
+    })");
+    LoadOutcome o2 = load(mixed);
+    CHECK(!o2.threw);
+    CHECK_EQ(o2.returned, true);
+    CHECK_EQ(ServerConfig::getBlacklist().size(), static_cast<size_t>(2));
+    CHECK_EQ(ServerConfig::getBlacklist()[0], std::string("192.0.2.30"));
+    CHECK_EQ(ServerConfig::getBlacklist()[1], std::string("192.0.2.31"));
+
+    // An explicit empty array clears the list.
+    std::string cleared = write_cfg("blacklist_empty.json", R"({"blacklist": []})");
+    CHECK_EQ(load(cleared).returned, true);
+    CHECK_EQ(ServerConfig::getBlacklist().size(), static_cast<size_t>(0));
+
+    // A non-array "blacklist" is ignored and leaves the current list intact.
+    ServerConfig::setBlacklist({"192.0.2.40"});
+    std::string notarr = write_cfg("blacklist_not_array.json",
+                                   R"({"blacklist": "192.0.2.99"})");
+    LoadOutcome o3 = load(notarr);
+    CHECK(!o3.threw);
+    CHECK_EQ(ServerConfig::getBlacklist().size(), static_cast<size_t>(1));
+    CHECK_EQ(ServerConfig::getBlacklist()[0], std::string("192.0.2.40"));
+}
+
+static void test_replace_templates_reach_url_rewriter()
+{
+    SUITE("loadFromFile: replace_templates array reaches URLRewriter");
+
+    reset_to_defaults();
+
+    // Baseline: install an empty template set, so the rewrite below is a pure
+    // prefix strip. URLRewriter's template store is process-global too.
+    std::string none = write_cfg("templates_none.json", R"({"replace_templates": []})");
+    CHECK_EQ(load(none).returned, true);
+
+    std::string out;
+    CHECK_EQ(URLRewriter::rewrite_path("/tv/192.0.2.10:554/live?a=1", out), true);
+    CHECK_EQ(out, std::string("rtsp://192.0.2.10:554/live?a=1"));
+
+    // Now install a real template and observe it take effect.
+    std::string path = write_cfg("templates.json", R"({
+        "replace_templates": [
+            { "action": "replace",
+              "match": "/tv/192.0.2.10",
+              "replacement": "/tv/192.0.2.11" }
+        ]
+    })");
+    LoadOutcome o = load(path);
+    CHECK(!o.threw);
+    CHECK_EQ(o.returned, true);
+
+    out.clear();
+    CHECK_EQ(URLRewriter::rewrite_path("/tv/192.0.2.10:554/live?a=1", out), true);
+    CHECK_EQ(out, std::string("rtsp://192.0.2.11:554/live?a=1"));
+
+    // Templates only apply to /tv/ URLs carrying a query string.
+    out.clear();
+    CHECK_EQ(URLRewriter::rewrite_path("/tv/192.0.2.10:554/live", out), true);
+    CHECK_EQ(out, std::string("rtsp://192.0.2.10:554/live"));
+
+    // Leave the global rewriter empty for anyone running after us.
+    CHECK_EQ(load(none).returned, true);
+}
+
+static void test_missing_file()
+{
+    SUITE("loadFromFile: a missing file returns false and changes nothing");
+
+    reset_to_defaults();
+    ServerConfig::setBlacklist({"192.0.2.50"});
+
+    std::string missing = g_dir + "/definitely_not_here.json";
+    LoadOutcome o = load(missing);
+
+    CHECK(!o.threw);
+    CHECK_EQ(o.returned, false);
+
+    CHECK_EQ(ServerConfig::getPort(), 8554);
+    CHECK_EQ(ServerConfig::getNatMethod(), std::string("stun"));
+    CHECK_EQ(ServerConfig::isNatEnabled(), false);
+    CHECK_EQ(ServerConfig::getBufferPoolCount(), 8192);
+    CHECK_EQ(ServerConfig::getBufferPoolBlockSize(), 2048);
+    CHECK_EQ(ServerConfig::getStunPort(), 19302);
+    CHECK_EQ(ServerConfig::getToken(), std::string(""));
+    CHECK_EQ(ServerConfig::getLogLines(), static_cast<size_t>(10000));
+    CHECK_EQ(ServerConfig::isStripPadding(), false);
+    CHECK_EQ(ServerConfig::isWaitKeyframe(), false);
+    CHECK_EQ(ServerConfig::getBlacklist().size(), static_cast<size_t>(1));
+}
+
+static void test_broken_json()
+{
+    SUITE("loadFromFile: syntactically broken JSON returns false, never throws");
+
+    reset_to_defaults();
+    ServerConfig::setPort(7777);
+
+    std::string path = write_cfg("broken.json", R"({ "settings": { "port": )");
+    LoadOutcome o = load(path);
+
+    CHECK(!o.threw);
+    CHECK_EQ(o.returned, false);
+    CHECK_EQ(ServerConfig::getPort(), 7777);
+
+    // A file that is not JSON at all behaves the same way.
+    std::string garbage = write_cfg("garbage.json", "this is not json at all\n");
+    LoadOutcome o2 = load(garbage);
+    CHECK(!o2.threw);
+    CHECK_EQ(o2.returned, false);
+    CHECK_EQ(ServerConfig::getPort(), 7777);
+
+    // An empty file is a parse error too (nlohmann requires a value).
+    std::string blank = write_cfg("blank.json", "");
+    LoadOutcome o3 = load(blank);
+    CHECK(!o3.threw);
+    CHECK_EQ(o3.returned, false);
+    CHECK_EQ(ServerConfig::getPort(), 7777);
+}
+
+static void test_wrong_typed_value()
+{
+    SUITE("loadFromFile: a wrong-typed settings value");
+
+    // loadFromFile wraps only nlohmann::json::parse() in a try/catch, and that
+    // catch clause is `catch (const nlohmann::json::parse_error&)`. The whole
+    // settings-application block below it is unguarded, so `s["port"].get<int>()`
+    // on a JSON *string* raises nlohmann::json::type_error (id 302,
+    // "type must be number, but is string") which escapes loadFromFile entirely.
+    // ProxyServer::run() happens to have an outer catch, but the contract of
+    // loadFromFile itself -- "returns bool, false on bad config" -- is violated.
+
+    reset_to_defaults();
+    ServerConfig::setPort(6001);
+    ServerConfig::setBlacklist({});
+
+    std::string path = write_cfg("wrong_type.json", R"({
+        "blacklist": ["192.0.2.60"],
+        "settings": { "port": "8554", "auth_token": "never-applied" }
+    })");
+
+    LoadOutcome o = load(path);
+
+    // Document precisely what escapes today.
+    CHECK_EQ(o.threw, true);
+    CHECK_EQ(o.kind, std::string("nlohmann::json::type_error"));
+    CHECK_EQ(o.json_id, 302);
+
+    // What it *should* do: reject the file the same way it rejects a syntax
+    // error -- report false, throw nothing.
+    XCHECK(!o.threw, "loadFromFile catches only nlohmann::json::parse_error, so a "
+                     "wrong-typed settings value throws json::type_error (302) out "
+                     "of the function instead of returning false");
+    XCHECK_EQ(o.outcome, std::string("false"),
+              "loadFromFile never returns on a type_error; it unwinds, so callers "
+              "cannot distinguish 'bad config' from 'no config'");
+
+    // The throw happens mid-application, so the file is applied partially:
+    // the blacklist landed, but auth_token (listed after "port") never did.
+    CHECK_EQ(ServerConfig::getPort(), 6001);
+    CHECK_EQ(ServerConfig::getToken(), std::string(""));
+    XCHECK_EQ(ServerConfig::getBlacklist().size(), static_cast<size_t>(0),
+              "a rejected config file is applied partially: the blacklist block "
+              "runs before the settings block and is not rolled back");
+
+    // Same failure mode for a wrong-typed bool.
+    reset_to_defaults();
+    std::string boolpath = write_cfg("wrong_type_bool.json", R"({
+        "settings": { "strip_padding": "yes" }
+    })");
+    LoadOutcome ob = load(boolpath);
+    CHECK_EQ(ob.kind, std::string("nlohmann::json::type_error"));
+    XCHECK_EQ(ob.outcome, std::string("false"),
+              "wrong-typed bool escapes as json::type_error instead of returning false");
+    CHECK_EQ(ServerConfig::isStripPadding(), false);
+}
+
+static void test_out_of_range_and_invalid_enum_values()
+{
+    SUITE("loadFromFile: values that are well-typed but rejected by the setters");
+
+    reset_to_defaults();
+    ServerConfig::setPort(6002);
+
+    // setPort() throws std::out_of_range; loadFromFile does not guard it either.
+    std::string bad_port = write_cfg("bad_port.json", R"({
+        "settings": { "port": 70000 }
+    })");
+    LoadOutcome o = load(bad_port);
+    CHECK_EQ(o.kind, std::string("std::out_of_range"));
+    XCHECK_EQ(o.outcome, std::string("false"),
+              "an out-of-range port makes setPort throw std::out_of_range straight "
+              "through loadFromFile instead of being reported as a load failure");
+    CHECK_EQ(ServerConfig::getPort(), 6002);
+
+    // setNatMethod() throws std::invalid_argument for anything but stun/zte.
+    reset_to_defaults();
+    std::string bad_method = write_cfg("bad_nat_method.json", R"({
+        "settings": { "nat_method": "upnp" }
+    })");
+    LoadOutcome o2 = load(bad_method);
+    CHECK_EQ(o2.kind, std::string("std::invalid_argument"));
+    XCHECK_EQ(o2.outcome, std::string("false"),
+              "an unknown nat_method throws std::invalid_argument out of loadFromFile "
+              "instead of being reported as a load failure");
+    CHECK_EQ(ServerConfig::getNatMethod(), std::string("stun"));
+
+    // Boundary values that are legal must be accepted without complaint.
+    reset_to_defaults();
+    std::string edges = write_cfg("edges.json", R"({
+        "settings": {
+            "port": 65535,
+            "buffer_pool_count": 1,
+            "buffer_pool_block_size": 64,
+            "stun_port": 1
+        }
+    })");
+    LoadOutcome o3 = load(edges);
+    CHECK(!o3.threw);
+    CHECK_EQ(o3.returned, true);
+    CHECK_EQ(ServerConfig::getPort(), 65535);
+    CHECK_EQ(ServerConfig::getBufferPoolCount(), 1);
+    CHECK_EQ(ServerConfig::getBufferPoolBlockSize(), 64);
+    CHECK_EQ(ServerConfig::getStunPort(), 1);
+}
+
+static void test_json_path_accessor()
+{
+    SUITE("json path accessor");
+
+    ServerConfig::setJsonPath("config.json");
+    CHECK_EQ(ServerConfig::getJsonPath(), std::string("config.json"));
+
+    std::string p = g_dir + "/somewhere.json";
+    ServerConfig::setJsonPath(p);
+    CHECK_EQ(ServerConfig::getJsonPath(), p);
+
+    // setJsonPath must not itself touch the filesystem.
+    std::ifstream probe(p);
+    CHECK(!probe.is_open());
+
+    ServerConfig::setJsonPath("config.json");
+}
+
+int main()
+{
+    if (!make_temp_dir())
+    {
+        std::printf("FATAL: could not create a temp directory\n");
+        return 1;
+    }
+    std::printf("temp dir: %s\n\n", g_dir.c_str());
+
+    // Keep the module's own logging out of the report.
+    Logger::setLogLevel(LogLevel::ERROR);
+
+    test_full_settings_block();
+    test_partial_settings_leave_the_rest_alone();
+    test_comments_are_tolerated();
+    test_blacklist();
+    test_replace_templates_reach_url_rewriter();
+    test_missing_file();
+    test_broken_json();
+    test_wrong_typed_value();
+    test_out_of_range_and_invalid_enum_values();
+    test_json_path_accessor();
+
+    reset_to_defaults();
+    cleanup_temp_dir();
+
+    return tst::summary();
+}

--- a/test/unit/test_server_config.cpp
+++ b/test/unit/test_server_config.cpp
@@ -421,13 +421,10 @@ static void test_wrong_typed_value()
 {
     SUITE("loadFromFile: a wrong-typed settings value");
 
-    // loadFromFile wraps only nlohmann::json::parse() in a try/catch, and that
-    // catch clause is `catch (const nlohmann::json::parse_error&)`. The whole
-    // settings-application block below it is unguarded, so `s["port"].get<int>()`
-    // on a JSON *string* raises nlohmann::json::type_error (id 302,
-    // "type must be number, but is string") which escapes loadFromFile entirely.
-    // ProxyServer::run() happens to have an outer catch, but the contract of
-    // loadFromFile itself -- "returns bool, false on bad config" -- is violated.
+    // `s["port"].get<int>()` on a JSON *string* raises nlohmann::json::type_error
+    // (id 302, "type must be number, but is string"). loadFromFile has to contain
+    // that and report it the way it reports a syntax error: return false, throw
+    // nothing, name the offending key in the log.
 
     reset_to_defaults();
     ServerConfig::setPort(6001);
@@ -440,37 +437,24 @@ static void test_wrong_typed_value()
 
     LoadOutcome o = load(path);
 
-    // Document precisely what escapes today.
-    CHECK_EQ(o.threw, true);
-    CHECK_EQ(o.kind, std::string("nlohmann::json::type_error"));
-    CHECK_EQ(o.json_id, 302);
+    CHECK(!o.threw);
+    CHECK_EQ(o.kind, std::string(""));
+    CHECK_EQ(o.outcome, std::string("false"));
 
-    // What it *should* do: reject the file the same way it rejects a syntax
-    // error -- report false, throw nothing.
-    XCHECK(!o.threw, "loadFromFile catches only nlohmann::json::parse_error, so a "
-                     "wrong-typed settings value throws json::type_error (302) out "
-                     "of the function instead of returning false");
-    XCHECK_EQ(o.outcome, std::string("false"),
-              "loadFromFile never returns on a type_error; it unwinds, so callers "
-              "cannot distinguish 'bad config' from 'no config'");
-
-    // The throw happens mid-application, so the file is applied partially:
-    // the blacklist landed, but auth_token (listed after "port") never did.
+    // A rejected file is applied all-or-nothing: the blacklist is staged and
+    // only committed once the settings block has gone through.
     CHECK_EQ(ServerConfig::getPort(), 6001);
     CHECK_EQ(ServerConfig::getToken(), std::string(""));
-    XCHECK_EQ(ServerConfig::getBlacklist().size(), static_cast<size_t>(0),
-              "a rejected config file is applied partially: the blacklist block "
-              "runs before the settings block and is not rolled back");
+    CHECK_EQ(ServerConfig::getBlacklist().size(), static_cast<size_t>(0));
 
-    // Same failure mode for a wrong-typed bool.
+    // Same handling for a wrong-typed bool.
     reset_to_defaults();
     std::string boolpath = write_cfg("wrong_type_bool.json", R"({
         "settings": { "strip_padding": "yes" }
     })");
     LoadOutcome ob = load(boolpath);
-    CHECK_EQ(ob.kind, std::string("nlohmann::json::type_error"));
-    XCHECK_EQ(ob.outcome, std::string("false"),
-              "wrong-typed bool escapes as json::type_error instead of returning false");
+    CHECK(!ob.threw);
+    CHECK_EQ(ob.outcome, std::string("false"));
     CHECK_EQ(ServerConfig::isStripPadding(), false);
 }
 
@@ -481,15 +465,13 @@ static void test_out_of_range_and_invalid_enum_values()
     reset_to_defaults();
     ServerConfig::setPort(6002);
 
-    // setPort() throws std::out_of_range; loadFromFile does not guard it either.
+    // setPort() throws std::out_of_range, which is not a JSON exception at all.
     std::string bad_port = write_cfg("bad_port.json", R"({
         "settings": { "port": 70000 }
     })");
     LoadOutcome o = load(bad_port);
-    CHECK_EQ(o.kind, std::string("std::out_of_range"));
-    XCHECK_EQ(o.outcome, std::string("false"),
-              "an out-of-range port makes setPort throw std::out_of_range straight "
-              "through loadFromFile instead of being reported as a load failure");
+    CHECK(!o.threw);
+    CHECK_EQ(o.outcome, std::string("false"));
     CHECK_EQ(ServerConfig::getPort(), 6002);
 
     // setNatMethod() throws std::invalid_argument for anything but stun/zte.
@@ -498,10 +480,8 @@ static void test_out_of_range_and_invalid_enum_values()
         "settings": { "nat_method": "upnp" }
     })");
     LoadOutcome o2 = load(bad_method);
-    CHECK_EQ(o2.kind, std::string("std::invalid_argument"));
-    XCHECK_EQ(o2.outcome, std::string("false"),
-              "an unknown nat_method throws std::invalid_argument out of loadFromFile "
-              "instead of being reported as a load failure");
+    CHECK(!o2.threw);
+    CHECK_EQ(o2.outcome, std::string("false"));
     CHECK_EQ(ServerConfig::getNatMethod(), std::string("stun"));
 
     // Boundary values that are legal must be accepted without complaint.
@@ -521,6 +501,93 @@ static void test_out_of_range_and_invalid_enum_values()
     CHECK_EQ(ServerConfig::getBufferPoolCount(), 1);
     CHECK_EQ(ServerConfig::getBufferPoolBlockSize(), 64);
     CHECK_EQ(ServerConfig::getStunPort(), 1);
+}
+
+static void test_rejected_file_is_applied_all_or_nothing()
+{
+    SUITE("loadFromFile: a rejected file leaves no half-applied state behind");
+
+    reset_to_defaults();
+    ServerConfig::setPort(6003);
+    ServerConfig::setToken("keep-me");
+    ServerConfig::setBlacklist({"192.0.2.70"});
+
+    // Every one of these is valid except nat_method, and "port" is applied
+    // before it; none of them may survive the rejection.
+    std::string path = write_cfg("mixed_valid_and_bad.json", R"({
+        "blacklist": ["192.0.2.71", "192.0.2.72"],
+        "settings": {
+            "port": 9300,
+            "nat_method": "upnp",
+            "auth_token": "never-applied",
+            "buffer_pool_count": 4096
+        },
+        "replace_templates": [
+            { "action": "replace", "match": "/tv/192.0.2.80", "replacement": "/tv/192.0.2.81" }
+        ]
+    })");
+
+    LoadOutcome o = load(path);
+    CHECK(!o.threw);
+    CHECK_EQ(o.outcome, std::string("false"));
+
+    CHECK_EQ(ServerConfig::getPort(), 6003);
+    CHECK_EQ(ServerConfig::getToken(), std::string("keep-me"));
+    CHECK_EQ(ServerConfig::getBufferPoolCount(), 8192);
+    CHECK_EQ(ServerConfig::getBlacklist().size(), static_cast<size_t>(1));
+    CHECK_EQ(ServerConfig::getBlacklist()[0], std::string("192.0.2.70"));
+
+    // replace_templates sits after the settings block, so it is not installed
+    // either: the rewriter still has whatever the previous load left there.
+    std::string out;
+    CHECK_EQ(URLRewriter::rewrite_path("/tv/192.0.2.80:554/live?a=1", out), true);
+    CHECK_EQ(out, std::string("rtsp://192.0.2.80:554/live?a=1"));
+
+    // log_level is applied mid-block, so it has to be rolled back too.
+    reset_to_defaults();
+    Logger::setLogLevel(LogLevel::ERROR);
+    std::string late = write_cfg("bad_after_log_level.json", R"({
+        "settings": { "log_level": "debug", "stun_port": 0 }
+    })");
+    LoadOutcome o2 = load(late);
+    CHECK(!o2.threw);
+    CHECK_EQ(o2.outcome, std::string("false"));
+    CHECK_EQ(static_cast<int>(Logger::getLogLevel()), static_cast<int>(LogLevel::ERROR));
+    CHECK_EQ(ServerConfig::getStunPort(), 19302);
+}
+
+static void test_unusable_replace_templates_are_dropped()
+{
+    SUITE("loadFromFile: replace_templates entries that can never fire are dropped");
+
+    reset_to_defaults();
+
+    // Only the last entry is usable; the rest have no string action/match, so
+    // rewrite_path could never apply them anyway.
+    std::string path = write_cfg("templates_junk.json", R"({
+        "replace_templates": [
+            "not-an-object",
+            42,
+            { "action": "replace" },
+            { "match": "/tv/192.0.2.90" },
+            { "action": 5, "match": "/tv/192.0.2.90" },
+            { "action": "replace",
+              "match": "/tv/192.0.2.90",
+              "replacement": "/tv/192.0.2.91" }
+        ]
+    })");
+
+    LoadOutcome o = load(path);
+    CHECK(!o.threw);
+    CHECK_EQ(o.returned, true);
+
+    std::string out;
+    CHECK_EQ(URLRewriter::rewrite_path("/tv/192.0.2.90:554/live?a=1", out), true);
+    CHECK_EQ(out, std::string("rtsp://192.0.2.91:554/live?a=1"));
+
+    // Leave the global rewriter empty for anyone running after us.
+    std::string none = write_cfg("templates_none2.json", R"({"replace_templates": []})");
+    CHECK_EQ(load(none).returned, true);
 }
 
 static void test_json_path_accessor()
@@ -562,6 +629,8 @@ int main()
     test_broken_json();
     test_wrong_typed_value();
     test_out_of_range_and_invalid_enum_values();
+    test_rejected_file_is_applied_all_or_nothing();
+    test_unusable_replace_templates_are_dropped();
     test_json_path_accessor();
 
     reset_to_defaults();

--- a/test/unit/test_stun_client.cpp
+++ b/test/unit/test_stun_client.cpp
@@ -1,0 +1,379 @@
+// Unit tests for StunClient.
+//
+// The RTP socket that carries a STUN exchange is a media socket: it accepts
+// datagrams from anywhere. Whatever comes back sets the public address the
+// proxy then advertises upstream, so every response has to be tied to the
+// request that was actually sent. These tests drive the real code over loopback
+// -- a second UDP socket plays the STUN server -- so the transaction ID under
+// test is the one the client genuinely put on the wire.
+//
+//   meson setup build -Dtests=true && meson test -C build stun_client
+
+#include "test_harness.h"
+
+#include "utils/stun_client.h"
+#include "core/server_config.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+constexpr uint32_t kMagicCookie = 0x2112A442;
+constexpr uint16_t kBindingRequest = 0x0001;
+constexpr uint16_t kBindingSuccess = 0x0101;
+constexpr uint16_t kBindingError = 0x0111;
+constexpr uint16_t kAttrMappedAddr = 0x0001;
+constexpr uint16_t kAttrXorMappedAddr = 0x0020;
+
+// A UDP socket bound to an ephemeral loopback port, used as the far end.
+struct LoopbackSocket
+{
+    int fd = -1;
+    uint16_t port = 0;
+
+    LoopbackSocket()
+    {
+        fd = socket(AF_INET, SOCK_DGRAM, 0);
+        if (fd < 0)
+            return;
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = 0;
+        if (bind(fd, (sockaddr *)&addr, sizeof(addr)) != 0)
+        {
+            close(fd);
+            fd = -1;
+            return;
+        }
+
+        sockaddr_in bound{};
+        socklen_t len = sizeof(bound);
+        if (getsockname(fd, (sockaddr *)&bound, &len) == 0)
+            port = ntohs(bound.sin_port);
+    }
+
+    ~LoopbackSocket()
+    {
+        if (fd >= 0)
+            close(fd);
+    }
+
+    LoopbackSocket(const LoopbackSocket &) = delete;
+    LoopbackSocket &operator=(const LoopbackSocket &) = delete;
+};
+
+void put16(unsigned char *p, uint16_t v) { uint16_t n = htons(v); std::memcpy(p, &n, 2); }
+void put32(unsigned char *p, uint32_t v) { uint32_t n = htonl(v); std::memcpy(p, &n, 4); }
+
+using TransactionId = std::vector<unsigned char>;
+
+// Read the request the client just sent and hand back its transaction ID.
+// Returns an empty vector if nothing arrived or the request is malformed.
+TransactionId receive_request(const LoopbackSocket &server)
+{
+    unsigned char req[64];
+    sockaddr_in from{};
+    socklen_t flen = sizeof(from);
+    ssize_t n = recvfrom(server.fd, req, sizeof(req), MSG_DONTWAIT,
+                         (sockaddr *)&from, &flen);
+    if (n != 20)
+        return {};
+
+    uint16_t type = 0;
+    uint32_t cookie = 0;
+    std::memcpy(&type, req + 0, 2);
+    std::memcpy(&cookie, req + 4, 4);
+    if (ntohs(type) != kBindingRequest || ntohl(cookie) != kMagicCookie)
+        return {};
+
+    return TransactionId(req + 8, req + 20);
+}
+
+// Build a STUN message carrying one address attribute.
+std::vector<unsigned char> make_response(uint16_t msg_type, uint32_t cookie,
+                                         const TransactionId &tid,
+                                         uint16_t attr_type,
+                                         const char *ip, uint16_t port)
+{
+    uint32_t addr = ntohl(inet_addr(ip));
+    uint16_t wire_port = port;
+    uint32_t wire_addr = addr;
+    if (attr_type == kAttrXorMappedAddr)
+    {
+        wire_port = port ^ static_cast<uint16_t>(kMagicCookie >> 16);
+        wire_addr = addr ^ kMagicCookie;
+    }
+
+    std::vector<unsigned char> msg(20 + 4 + 8, 0);
+    put16(msg.data() + 0, msg_type);
+    put16(msg.data() + 2, 12); // attribute section length
+    put32(msg.data() + 4, cookie);
+    std::memcpy(msg.data() + 8, tid.data(), tid.size());
+
+    put16(msg.data() + 20, attr_type);
+    put16(msg.data() + 22, 8);
+    msg[24] = 0x00;            // reserved
+    msg[25] = 0x01;            // family: IPv4
+    put16(msg.data() + 26, wire_port);
+    put32(msg.data() + 28, wire_addr);
+    return msg;
+}
+
+// Send a fresh request and return the transaction ID the server observed.
+TransactionId issue_request(int client_fd, const LoopbackSocket &server)
+{
+    if (StunClient::send_stun_mapping_request(client_fd) != 0)
+        return {};
+    return receive_request(server);
+}
+
+int extract(int fd, std::vector<unsigned char> &msg, std::string &ip, uint16_t &port)
+{
+    ip.clear();
+    port = 0;
+    return StunClient::extract_stun_mapping_from_response(fd, msg.data(), msg.size(), ip, port);
+}
+
+/* ------------------------------------------------------------------ */
+
+void test_happy_path(const LoopbackSocket &server)
+{
+    SUITE("extract: a well-formed XOR-MAPPED-ADDRESS response is accepted");
+
+    LoopbackSocket client;
+    CHECK(client.fd >= 0);
+
+    TransactionId tid = issue_request(client.fd, server);
+    CHECK_EQ((int)tid.size(), 12);
+
+    auto msg = make_response(kBindingSuccess, kMagicCookie, tid,
+                             kAttrXorMappedAddr, "203.0.113.7", 41000);
+    std::string ip;
+    uint16_t port = 0;
+    CHECK_EQ(extract(client.fd, msg, ip, port), 0);
+    CHECK_EQ(ip, std::string("203.0.113.7"));
+    CHECK_EQ(port, 41000);
+}
+
+void test_plain_mapped_address(const LoopbackSocket &server)
+{
+    SUITE("extract: the legacy MAPPED-ADDRESS attribute also works");
+
+    LoopbackSocket client;
+    TransactionId tid = issue_request(client.fd, server);
+    CHECK_EQ((int)tid.size(), 12);
+
+    auto msg = make_response(kBindingSuccess, kMagicCookie, tid,
+                             kAttrMappedAddr, "198.51.100.9", 5060);
+    std::string ip;
+    uint16_t port = 0;
+    CHECK_EQ(extract(client.fd, msg, ip, port), 0);
+    CHECK_EQ(ip, std::string("198.51.100.9"));
+    CHECK_EQ(port, 5060);
+}
+
+void test_wrong_transaction_id(const LoopbackSocket &server)
+{
+    SUITE("extract: a response with someone else's transaction ID is rejected");
+
+    LoopbackSocket client;
+    TransactionId tid = issue_request(client.fd, server);
+    CHECK_EQ((int)tid.size(), 12);
+
+    // An off-path attacker who sprays the media port knows the magic cookie --
+    // it is a constant -- but not the 96-bit transaction ID.
+    TransactionId forged(12, 0xAB);
+    CHECK(forged != tid);
+
+    auto msg = make_response(kBindingSuccess, kMagicCookie, forged,
+                             kAttrXorMappedAddr, "6.6.6.6", 1234);
+    std::string ip;
+    uint16_t port = 0;
+    CHECK_EQ(extract(client.fd, msg, ip, port), -1);
+    CHECK_EQ(ip, std::string(""));
+    CHECK_EQ(port, 0);
+}
+
+void test_wrong_message_type(const LoopbackSocket &server)
+{
+    SUITE("extract: only a Binding Success Response carries a mapping");
+
+    {
+        LoopbackSocket client;
+        TransactionId tid = issue_request(client.fd, server);
+        auto msg = make_response(kBindingError, kMagicCookie, tid,
+                                 kAttrXorMappedAddr, "6.6.6.6", 1234);
+        std::string ip;
+        uint16_t port = 0;
+        CHECK_EQ(extract(client.fd, msg, ip, port), -1);
+        CHECK_EQ(port, 0);
+    }
+
+    {
+        // A reflected copy of our own request must not be read as an answer.
+        LoopbackSocket client;
+        TransactionId tid = issue_request(client.fd, server);
+        auto msg = make_response(kBindingRequest, kMagicCookie, tid,
+                                 kAttrXorMappedAddr, "6.6.6.6", 1234);
+        std::string ip;
+        uint16_t port = 0;
+        CHECK_EQ(extract(client.fd, msg, ip, port), -1);
+        CHECK_EQ(port, 0);
+    }
+}
+
+void test_wrong_cookie(const LoopbackSocket &server)
+{
+    SUITE("extract: the magic cookie is still required");
+
+    LoopbackSocket client;
+    TransactionId tid = issue_request(client.fd, server);
+    auto msg = make_response(kBindingSuccess, 0xDEADBEEF, tid,
+                             kAttrXorMappedAddr, "6.6.6.6", 1234);
+    std::string ip;
+    uint16_t port = 0;
+    CHECK_EQ(extract(client.fd, msg, ip, port), -1);
+    CHECK_EQ(port, 0);
+}
+
+void test_no_request_in_flight(const LoopbackSocket &server)
+{
+    SUITE("extract: a socket that never asked accepts nothing");
+
+    LoopbackSocket other;
+    TransactionId tid = issue_request(other.fd, server);
+    CHECK_EQ((int)tid.size(), 12);
+
+    // Perfectly valid message, but addressed at a socket with no outstanding
+    // request -- which is what an unsolicited datagram looks like.
+    LoopbackSocket quiet;
+    auto msg = make_response(kBindingSuccess, kMagicCookie, tid,
+                             kAttrXorMappedAddr, "6.6.6.6", 1234);
+    std::string ip;
+    uint16_t port = 0;
+    CHECK_EQ(extract(quiet.fd, msg, ip, port), -1);
+    CHECK_EQ(port, 0);
+}
+
+void test_response_is_single_use(const LoopbackSocket &server)
+{
+    SUITE("extract: one request accepts exactly one answer");
+
+    LoopbackSocket client;
+    TransactionId tid = issue_request(client.fd, server);
+    auto msg = make_response(kBindingSuccess, kMagicCookie, tid,
+                             kAttrXorMappedAddr, "203.0.113.7", 41000);
+
+    std::string ip;
+    uint16_t port = 0;
+    CHECK_EQ(extract(client.fd, msg, ip, port), 0);
+    CHECK_EQ(port, 41000);
+
+    // Replaying it must not work: the exchange is over.
+    auto replay = make_response(kBindingSuccess, kMagicCookie, tid,
+                                kAttrXorMappedAddr, "6.6.6.6", 1234);
+    CHECK_EQ(extract(client.fd, replay, ip, port), -1);
+    CHECK_EQ(port, 0);
+}
+
+void test_truncated_and_lying_lengths(const LoopbackSocket &server)
+{
+    SUITE("extract: malformed messages are rejected without reading past the end");
+
+    {
+        LoopbackSocket client;
+        TransactionId tid = issue_request(client.fd, server);
+        auto msg = make_response(kBindingSuccess, kMagicCookie, tid,
+                                 kAttrXorMappedAddr, "203.0.113.7", 41000);
+        msg.resize(19); // shorter than a STUN header
+        std::string ip;
+        uint16_t port = 0;
+        CHECK_EQ(extract(client.fd, msg, ip, port), -1);
+    }
+
+    {
+        // Attribute claims 4 KiB of value inside a 32-byte datagram.
+        LoopbackSocket client;
+        TransactionId tid = issue_request(client.fd, server);
+        auto msg = make_response(kBindingSuccess, kMagicCookie, tid,
+                                 kAttrXorMappedAddr, "203.0.113.7", 41000);
+        put16(msg.data() + 2, 4096);
+        put16(msg.data() + 22, 4092);
+        std::string ip;
+        uint16_t port = 0;
+        CHECK_EQ(extract(client.fd, msg, ip, port), -1);
+        CHECK_EQ(port, 0);
+    }
+
+    {
+        // Header present, no attributes at all.
+        LoopbackSocket client;
+        TransactionId tid = issue_request(client.fd, server);
+        auto msg = make_response(kBindingSuccess, kMagicCookie, tid,
+                                 kAttrXorMappedAddr, "203.0.113.7", 41000);
+        msg.resize(20);
+        put16(msg.data() + 2, 0);
+        std::string ip;
+        uint16_t port = 0;
+        CHECK_EQ(extract(client.fd, msg, ip, port), -1);
+    }
+}
+
+void test_transaction_ids_differ(const LoopbackSocket &server)
+{
+    SUITE("gen_tid: back-to-back requests use different transaction IDs");
+
+    // The old implementation re-seeded srand() from time(nullptr) on every
+    // call, so two requests issued within the same second drew an identical
+    // transaction ID -- which would make the check above worthless.
+    LoopbackSocket a, b, c;
+    TransactionId ta = issue_request(a.fd, server);
+    TransactionId tb = issue_request(b.fd, server);
+    TransactionId tc = issue_request(c.fd, server);
+
+    CHECK_EQ((int)ta.size(), 12);
+    CHECK_EQ((int)tb.size(), 12);
+    CHECK_EQ((int)tc.size(), 12);
+    CHECK(ta != tb);
+    CHECK(tb != tc);
+    CHECK(ta != tc);
+}
+
+} // namespace
+
+int main()
+{
+    LoopbackSocket server;
+    if (server.fd < 0 || server.port == 0)
+    {
+        std::printf("FATAL: could not bind a loopback UDP socket\n");
+        return 1;
+    }
+
+    // Point the client at our stand-in server. sendto() to loopback needs no
+    // listener, but binding one lets the test read back the real request.
+    ServerConfig::setStunHost("127.0.0.1");
+    ServerConfig::setStunPort(server.port);
+
+    test_happy_path(server);
+    test_plain_mapped_address(server);
+    test_wrong_transaction_id(server);
+    test_wrong_message_type(server);
+    test_wrong_cookie(server);
+    test_no_request_in_flight(server);
+    test_response_is_single_use(server);
+    test_truncated_and_lying_lengths(server);
+    test_transaction_ids_differ(server);
+
+    return tst::summary();
+}

--- a/test/unit/test_url_rewriter.cpp
+++ b/test/unit/test_url_rewriter.cpp
@@ -1,0 +1,368 @@
+// Unit tests for URLRewriter (src/utils/url_rewriter.cpp).
+//
+// URLRewriter is entirely static and has no ServerConfig / socket / DNS
+// dependencies -- rewrite_path() is pure string work -- so the only global
+// state that has to be pinned per test group is the template list itself
+// (set_replace_templates) and the process timezone (shiftTime() goes through
+// mktime()/localtime() for the 14-char form). Both are set explicitly below so
+// the groups are order-independent.
+//
+// simplifyToRegex() and shiftTime() are private, so they are exercised through
+// rewrite_path() with purpose-built templates.
+//
+// Build and run:
+//   meson setup build -Dtests=true && meson test -C build url_rewriter
+
+#include "test_harness.h"
+
+#include "utils/url_rewriter.h"
+#include "core/logger.h"
+
+#include <cstdlib>
+#include <ctime>
+#include <string>
+
+using json = nlohmann::json;
+
+namespace
+{
+
+// Convenience: run rewrite_path with a fresh output string.
+std::string rewrite(const std::string &url, bool &ok)
+{
+    std::string out;
+    ok = URLRewriter::rewrite_path(url, out);
+    return out;
+}
+
+// Same, but only the produced URL matters.
+std::string rewrite(const std::string &url)
+{
+    bool ok = false;
+    return rewrite(url, ok);
+}
+
+void set_templates(const char *json_text)
+{
+    URLRewriter::set_replace_templates(json::parse(json_text));
+}
+
+void no_templates()
+{
+    URLRewriter::set_replace_templates(json::array());
+}
+
+// ---------------------------------------------------------------------------
+
+void test_prefix_handling()
+{
+    SUITE("rewrite_path: /rtp/ and /tv/ prefix handling");
+    no_templates();
+
+    bool ok = false;
+
+    // The two accepted prefixes are stripped and replaced with "rtsp://".
+    CHECK_EQ(rewrite("/rtp/239.1.1.1:5000", ok), std::string("rtsp://239.1.1.1:5000"));
+    CHECK(ok);
+    CHECK_EQ(rewrite("/tv/192.0.2.10:554/live/1", ok), std::string("rtsp://192.0.2.10:554/live/1"));
+    CHECK(ok);
+
+    // Query strings survive the prefix strip untouched when no template matches.
+    CHECK_EQ(rewrite("/rtp/239.1.1.1:5000?a=1"), std::string("rtsp://239.1.1.1:5000?a=1"));
+
+    // Anything else is rejected.
+    std::string out = "SENTINEL";
+    CHECK(!URLRewriter::rewrite_path("/foo/bar", out));
+    CHECK_EQ(out, std::string("SENTINEL")); // rtsp_url is left untouched on failure
+
+    // The prefix must sit at offset 0, not merely appear somewhere.
+    out = "SENTINEL";
+    CHECK(!URLRewriter::rewrite_path("/x/rtp/239.1.1.1:5000", out));
+    CHECK_EQ(out, std::string("SENTINEL"));
+
+    // Matching is case sensitive.
+    CHECK(!URLRewriter::rewrite_path("/TV/192.0.2.10", out));
+
+    // A bare prefix carries no upstream path and is rejected.
+    CHECK(!URLRewriter::rewrite_path("/tv/", out));
+    CHECK(!URLRewriter::rewrite_path("/rtp/", out));
+    CHECK(!URLRewriter::rewrite_path("/tv", out));
+
+    // One character past the prefix is enough.
+    CHECK_EQ(rewrite("/tv/x"), std::string("rtsp://x"));
+    CHECK_EQ(rewrite("/rtp/x"), std::string("rtsp://x"));
+}
+
+void test_template_gating()
+{
+    SUITE("rewrite_path: when templates are applied at all");
+
+    set_templates(R"([{"action":"remove","match":"/live/{number}"}])");
+
+    // Templates only run for /tv/ URLs that carry a query string -- this is the
+    // documented design ("playback links usually have query params").
+    CHECK_EQ(rewrite("/tv/192.0.2.10/live/7?x=1"), std::string("rtsp://192.0.2.10?x=1"));
+    // No '?' -> the rule is skipped even though it would have matched.
+    CHECK_EQ(rewrite("/tv/192.0.2.10/live/7"), std::string("rtsp://192.0.2.10/live/7"));
+    // /rtp/ never runs templates, query string or not.
+    CHECK_EQ(rewrite("/rtp/192.0.2.10/live/7?x=1"), std::string("rtsp://192.0.2.10/live/7?x=1"));
+
+    // An empty array and a null json are both "no rules".
+    no_templates();
+    CHECK_EQ(rewrite("/tv/192.0.2.10/live/7?x=1"), std::string("rtsp://192.0.2.10/live/7?x=1"));
+    URLRewriter::set_replace_templates(json());
+    CHECK_EQ(rewrite("/tv/192.0.2.10/live/7?x=1"), std::string("rtsp://192.0.2.10/live/7?x=1"));
+}
+
+void test_placeholder_expansion()
+{
+    SUITE("simplifyToRegex: {number} / {word} / {any} expansion");
+
+    // Single placeholder, capture group is usable from the replacement.
+    set_templates(R"([{"action":"replace","match":"seek={number}","replacement":"S=$1"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?seek=1234"), std::string("rtsp://192.0.2.10/c?S=1234"));
+
+    set_templates(R"([{"action":"replace","match":"id={word}","replacement":"W=$1"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?id=abc"), std::string("rtsp://192.0.2.10/c?W=abc"));
+
+    // {any} expands to a lazy group, so it stops at the following literal.
+    set_templates(R"([{"action":"replace","match":"p={any}z","replacement":"A=[$1]"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?p=helloz&q=2"),
+             std::string("rtsp://192.0.2.10/c?A=[hello]&q=2"));
+
+    // --- regression: two ADJACENT placeholders ---------------------------
+    // The erase length must be the placeholder's own length and the advance
+    // must be the replacement's length (5). If the advance is too large the
+    // second placeholder is stepped over and survives verbatim, which then
+    // makes std::regex reject "{number}" as a bad quantifier.
+    set_templates(R"([{"action":"replace","match":"seek={number}{number}","replacement":"S=$1|$2"}])");
+    bool ok = false;
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?seek=1234", ok), std::string("rtsp://192.0.2.10/c?S=123|4"));
+    CHECK(ok);
+
+    set_templates(R"([{"action":"replace","match":"n={number}{number}{number}","replacement":"[$1][$2][$3]"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?n=12345"), std::string("rtsp://192.0.2.10/c?[123][4][5]"));
+
+    set_templates(R"([{"action":"replace","match":"m={word}{number}n","replacement":"[$1][$2]"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?m=abc12n"), std::string("rtsp://192.0.2.10/c?[abc1][2]"));
+
+    // --- regression: placeholder immediately followed by a literal --------
+    // If the erase length is short/long the neighbouring literal is either
+    // swallowed or leftover placeholder text is kept.
+    set_templates(R"([{"action":"replace","match":"seek={number}s","replacement":"T=$1"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?seek=99s&z=1", ok), std::string("rtsp://192.0.2.10/c?T=99&z=1"));
+    CHECK(ok);
+
+    set_templates(R"([{"action":"replace","match":"id={word}-","replacement":"W=$1;"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?id=abc-1"), std::string("rtsp://192.0.2.10/c?W=abc;1"));
+
+    set_templates(R"([{"action":"replace","match":"q={any}!","replacement":"A=$1"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?q=xy!&r=3"), std::string("rtsp://192.0.2.10/c?A=xy&r=3"));
+
+    // '/' is escaped to "\/" (harmless in ECMAScript, but the escape loop must
+    // not corrupt the pattern or drop following characters).
+    set_templates(R"([{"action":"replace","match":"/live/{number}","replacement":"/L$1"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/live/7?x=1"), std::string("rtsp://192.0.2.10/L7?x=1"));
+
+    set_templates(R"([{"action":"remove","match":"/a/b/c/"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/a/b/c/d?x=1"), std::string("rtsp://192.0.2.10d?x=1"));
+}
+
+void test_actions()
+{
+    SUITE("rewrite_path: remove / replace actions");
+
+    // remove: the shipped "delete redundant field" rule.
+    set_templates(R"([{"action":"remove","match":"/{number}_Uni.sdp"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/PLTV/224/3221226109/1_Uni.sdp?a=1"),
+             std::string("rtsp://192.0.2.10/PLTV/224/3221226109?a=1"));
+
+    // remove with no placeholders at all.
+    set_templates(R"([{"action":"remove","match":"/iptv/import"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/iptv/import/live?x=1"),
+             std::string("rtsp://192.0.2.10/live?x=1"));
+
+    // replace, literal -> literal.
+    set_templates(R"([{"action":"replace","match":"/iptv/import","replacement":"/iptv"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/iptv/import/live?x=1"),
+             std::string("rtsp://192.0.2.10/iptv/live?x=1"));
+
+    // Every occurrence is rewritten, not just the first.
+    set_templates(R"([{"action":"remove","match":"&drop={number}"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?a=1&drop=1&b=2&drop=22"),
+             std::string("rtsp://192.0.2.10/c?a=1&b=2"));
+
+    // Templates are applied in array order, each seeing the previous result.
+    set_templates(R"([
+        {"action":"replace","match":"/iptv/import","replacement":"/iptv"},
+        {"action":"remove","match":"/{number}_Uni.sdp"}
+    ])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/iptv/import/1_Uni.sdp?a=1"),
+             std::string("rtsp://192.0.2.10/iptv?a=1"));
+
+    // An unknown action is a silent no-op (no throw, request still succeeds).
+    set_templates(R"([{"action":"nosuchaction","match":"/live/{number}"}])");
+    bool ok = false;
+    CHECK_EQ(rewrite("/tv/192.0.2.10/live/7?x=1", ok), std::string("rtsp://192.0.2.10/live/7?x=1"));
+    CHECK(ok);
+}
+
+void test_timeshift()
+{
+    SUITE("timeshift action + shiftTime()");
+
+    // Pin the timezone: the 14-char branch round-trips through
+    // mktime()/localtime(), which are locale/TZ dependent.
+    setenv("TZ", "UTC", 1);
+    tzset();
+
+    // --- 14-char YYYYmmddHHMMSS form ---
+    set_templates(R"([{"action":"timeshift","match":"playseek={number}-{number}","shift_hours":8}])");
+    bool ok = false;
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?playseek=20240101120000-20240101130000", ok),
+             std::string("rtsp://192.0.2.10/c?playseek=20240101200000-20240101210000"));
+    CHECK(ok);
+
+    // Negative shift, rolling back over a month/year boundary.
+    set_templates(R"([{"action":"timeshift","match":"playseek={number}-{number}","shift_hours":-8}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?playseek=20240101020000-20240101030000"),
+             std::string("rtsp://192.0.2.10/c?playseek=20231231180000-20231231190000"));
+
+    // shift_hours == 0 is an identity transform.
+    set_templates(R"([{"action":"timeshift","match":"playseek={number}-{number}","shift_hours":0}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?playseek=20240101120000-20240101130000"),
+             std::string("rtsp://192.0.2.10/c?playseek=20240101120000-20240101130000"));
+
+    // --- epoch form (<= 10 chars) : converted to 14-char UTC wall clock ---
+    // 1704110400 == 2024-01-01T12:00:00Z, 1704114000 == 13:00:00Z; +1h each.
+    set_templates(R"([{"action":"timeshift","match":"playseek={number}-{number}","shift_hours":1}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?playseek=1704110400-1704114000"),
+             std::string("rtsp://192.0.2.10/c?playseek=20240101130000-20240101140000"));
+
+    // Tiny epoch values still go down the epoch branch.
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?playseek=0-60"),
+             std::string("rtsp://192.0.2.10/c?playseek=19700101010000-19700101010100"));
+
+    // --- lengths that are neither 14 nor <= 10 are returned verbatim ---
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?playseek=202401011200-202401011300"),
+             std::string("rtsp://192.0.2.10/c?playseek=202401011200-202401011300"));
+    // 15+ digits likewise.
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?playseek=202401011200001-202401011300001"),
+             std::string("rtsp://192.0.2.10/c?playseek=202401011200001-202401011300001"));
+
+    // A timeshift rule with a single capture group needs match.size() >= 3 and
+    // is therefore a silent no-op -- documented here so the guard is not
+    // "fixed" by accident.
+    set_templates(R"([{"action":"timeshift","match":"t={number}","shift_hours":1}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?t=1704110400", ok),
+             std::string("rtsp://192.0.2.10/c?t=1704110400"));
+    CHECK(ok);
+
+    // A pattern that simply does not occur leaves the URL alone.
+    set_templates(R"([{"action":"timeshift","match":"playseek={number}-{number}","shift_hours":8}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?other=1"), std::string("rtsp://192.0.2.10/c?other=1"));
+
+    // --- KNOWN BUG -------------------------------------------------------
+    // The rewrite locates the two times inside match[0] with find() instead of
+    // using the capture-group offsets, so a digit in the pattern's own literal
+    // text is clobbered before the real timestamp is reached.
+    set_templates(R"([{"action":"timeshift","match":"s2={number}-{number}","shift_hours":1}])");
+    std::string got = rewrite("/tv/192.0.2.10/c?s2=2-3", ok);
+    CHECK(ok); // the request itself must still succeed
+    XCHECK_EQ(got, std::string("rtsp://192.0.2.10/c?s2=19700101010002-19700101010003"),
+              "shiftTime substitution uses full_match.find(start_time) instead of the "
+              "capture offsets, so the digit in the literal prefix 's2=' is overwritten");
+}
+
+void test_regex_metacharacters()
+{
+    SUITE("simplifyToRegex: unescaped regex metacharacters in match patterns");
+
+    // simplifyToRegex only escapes '/', so a perfectly natural config pattern
+    // such as "?playseek={number}" becomes the invalid regex "?playseek=(\d+)".
+    set_templates(R"([{"action":"remove","match":"?playseek={number}"}])");
+
+    bool ok = true;
+    std::string out = "SENTINEL";
+    bool threw = false;
+    try {
+        ok = URLRewriter::rewrite_path("/tv/192.0.2.10/c?playseek=100&b=2", out);
+    } catch (...) {
+        threw = true;
+    }
+    // Whatever else happens, the std::regex_error must not escape rewrite_path.
+    CHECK(!threw);
+    // ...and rtsp_url must not be left half-written when it bails out.
+    CHECK_EQ(out, std::string("SENTINEL"));
+    // The rule should have been treated as a literal '?' and the request should
+    // have succeeded; instead one bad rule fails the entire request.
+    XCHECK(ok, "simplifyToRegex does not escape regex metacharacters: a '?' in a match "
+               "pattern throws std::regex_error and rewrite_path fails the whole request");
+    XCHECK_EQ(out, std::string("rtsp://192.0.2.10/c&b=2"),
+              "same bug: '?' should be matched literally");
+
+    // An unbalanced '(' is the same class of failure.
+    set_templates(R"([{"action":"remove","match":"(live"}])");
+    out = "SENTINEL";
+    CHECK(!URLRewriter::rewrite_path("/tv/192.0.2.10/(live?x=1", out));
+
+    // '.' is silently treated as "any character" rather than a literal dot.
+    set_templates(R"([{"action":"replace","match":"id=1.2","replacement":"OK"}])");
+    std::string got = rewrite("/tv/192.0.2.10/c?id=1x2");
+    XCHECK_EQ(got, std::string("rtsp://192.0.2.10/c?id=1x2"),
+              "'.' in a match pattern is not escaped, so it matches any character");
+}
+
+void test_shipped_config_chain()
+{
+    SUITE("replace_templates chain as shipped in config.json");
+
+    // The four rules from config.json, verbatim (comments stripped).
+    set_templates(R"([
+        {"action":"remove","match":"/{number}_Uni.sdp"},
+        {"action":"replace","match":"/iptv/import","replacement":"/iptv"},
+        {"action":"replace","match":"tvdr={number}-{number}","replacement":"tvdr={number}GMT-{number}GMT"},
+        {"action":"timeshift","match":"tvdr={number}GMT-{number}GMT","shift_hours":-8}
+    ])");
+
+    setenv("TZ", "UTC", 1);
+    tzset();
+
+    // A live URL with no query string is untouched by the chain.
+    CHECK_EQ(rewrite("/tv/192.0.2.10/PLTV/224/3221226109/1_Uni.sdp"),
+             std::string("rtsp://192.0.2.10/PLTV/224/3221226109/1_Uni.sdp"));
+
+    // With a query string the remove + replace rules do fire.
+    CHECK_EQ(rewrite("/tv/192.0.2.10/iptv/import/1_Uni.sdp?a=1"),
+             std::string("rtsp://192.0.2.10/iptv?a=1"));
+
+    // The playback chain should annotate both timestamps with "GMT" and then
+    // shift them by -8h. It does not: simplifyToRegex is applied to "match"
+    // only, so the "{number}" tokens in "replacement" are inserted literally
+    // and the following timeshift rule then finds no digits to shift.
+    bool ok = false;
+    std::string got = rewrite("/tv/192.0.2.10/PLTV/c?tvdr=20240101120000-20240101130000", ok);
+    CHECK(ok);
+    CHECK_EQ(got, std::string("rtsp://192.0.2.10/PLTV/c?tvdr={number}GMT-{number}GMT"));
+    XCHECK_EQ(got, std::string("rtsp://192.0.2.10/PLTV/c?tvdr=20240101040000GMT-20240101050000GMT"),
+              "placeholders are never expanded in the 'replacement' field (only $1/$2 work), "
+              "so the shipped playback rewrite emits literal '{number}' and the timeshift "
+              "rule that follows it never matches");
+}
+
+} // namespace
+
+int main()
+{
+    Logger::setLogLevel(LogLevel::ERROR);
+
+    test_prefix_handling();
+    test_template_gating();
+    test_placeholder_expansion();
+    test_actions();
+    test_timeshift();
+    test_regex_metacharacters();
+    test_shipped_config_chain();
+
+    return tst::summary();
+}

--- a/test/unit/test_url_rewriter.cpp
+++ b/test/unit/test_url_rewriter.cpp
@@ -262,27 +262,35 @@ void test_timeshift()
     set_templates(R"([{"action":"timeshift","match":"playseek={number}-{number}","shift_hours":8}])");
     CHECK_EQ(rewrite("/tv/192.0.2.10/c?other=1"), std::string("rtsp://192.0.2.10/c?other=1"));
 
-    // --- KNOWN BUG -------------------------------------------------------
-    // The rewrite locates the two times inside match[0] with find() instead of
-    // using the capture-group offsets, so a digit in the pattern's own literal
-    // text is clobbered before the real timestamp is reached.
+    // --- splicing is done by capture-group offset --------------------------
+    // A digit inside the pattern's own literal text ('s2=') must survive: only
+    // the two captured timestamps are rewritten.
     set_templates(R"([{"action":"timeshift","match":"s2={number}-{number}","shift_hours":1}])");
     std::string got = rewrite("/tv/192.0.2.10/c?s2=2-3", ok);
-    CHECK(ok); // the request itself must still succeed
-    XCHECK_EQ(got, std::string("rtsp://192.0.2.10/c?s2=19700101010002-19700101010003"),
-              "shiftTime substitution uses full_match.find(start_time) instead of the "
-              "capture offsets, so the digit in the literal prefix 's2=' is overwritten");
+    CHECK(ok);
+    CHECK_EQ(got, std::string("rtsp://192.0.2.10/c?s2=19700101010002-19700101010003"));
+
+    // Both groups grow from 10 to 14 characters, so the second one has to be
+    // spliced first for the first one's offset to still be valid.
+    set_templates(R"([{"action":"timeshift","match":"playseek={number}-{number}","shift_hours":1}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?playseek=0-60&z=9"),
+             std::string("rtsp://192.0.2.10/c?playseek=19700101010000-19700101010100&z=9"));
+
+    // timeshift uses regex_search, so only the first occurrence is shifted.
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?playseek=0-60&playseek=0-60"),
+             std::string("rtsp://192.0.2.10/c?playseek=19700101010000-19700101010100&playseek=0-60"));
 }
 
 void test_regex_metacharacters()
 {
-    SUITE("simplifyToRegex: unescaped regex metacharacters in match patterns");
+    SUITE("simplifyToRegex: regex metacharacters in match patterns stay literal");
 
-    // simplifyToRegex only escapes '/', so a perfectly natural config pattern
-    // such as "?playseek={number}" becomes the invalid regex "?playseek=(\d+)".
+    // A perfectly natural config pattern such as "?playseek={number}" has to be
+    // read as a literal '?' rather than compiled as the invalid regex
+    // "?playseek=(\d+)".
     set_templates(R"([{"action":"remove","match":"?playseek={number}"}])");
 
-    bool ok = true;
+    bool ok = false;
     std::string out = "SENTINEL";
     bool threw = false;
     try {
@@ -292,25 +300,108 @@ void test_regex_metacharacters()
     }
     // Whatever else happens, the std::regex_error must not escape rewrite_path.
     CHECK(!threw);
-    // ...and rtsp_url must not be left half-written when it bails out.
-    CHECK_EQ(out, std::string("SENTINEL"));
-    // The rule should have been treated as a literal '?' and the request should
-    // have succeeded; instead one bad rule fails the entire request.
-    XCHECK(ok, "simplifyToRegex does not escape regex metacharacters: a '?' in a match "
-               "pattern throws std::regex_error and rewrite_path fails the whole request");
-    XCHECK_EQ(out, std::string("rtsp://192.0.2.10/c&b=2"),
-              "same bug: '?' should be matched literally");
+    CHECK(ok);
+    CHECK_EQ(out, std::string("rtsp://192.0.2.10/c&b=2"));
 
-    // An unbalanced '(' is the same class of failure.
+    // An unbalanced '(' is no longer a broken regex either.
     set_templates(R"([{"action":"remove","match":"(live"}])");
-    out = "SENTINEL";
-    CHECK(!URLRewriter::rewrite_path("/tv/192.0.2.10/(live?x=1", out));
+    CHECK_EQ(rewrite("/tv/192.0.2.10/(live?x=1"), std::string("rtsp://192.0.2.10/?x=1"));
 
-    // '.' is silently treated as "any character" rather than a literal dot.
+    // '.' is a literal dot, so it no longer matches an arbitrary character.
     set_templates(R"([{"action":"replace","match":"id=1.2","replacement":"OK"}])");
-    std::string got = rewrite("/tv/192.0.2.10/c?id=1x2");
-    XCHECK_EQ(got, std::string("rtsp://192.0.2.10/c?id=1x2"),
-              "'.' in a match pattern is not escaped, so it matches any character");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?id=1x2"), std::string("rtsp://192.0.2.10/c?id=1x2"));
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?id=1.2"), std::string("rtsp://192.0.2.10/c?OK"));
+
+    // The rest of the metacharacter set behaves the same way.
+    set_templates(R"([{"action":"remove","match":"^a$b|c*d+e[f]g"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?^a$b|c*d+e[f]g&x=1"),
+             std::string("rtsp://192.0.2.10/c?&x=1"));
+
+    // Braces that do not spell one of the three documented placeholders are
+    // literal braces, not a regex repetition.
+    set_templates(R"([{"action":"remove","match":"{foo}"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/{foo}/x?a=1"), std::string("rtsp://192.0.2.10//x?a=1"));
+
+    // A backslash matches a backslash instead of starting an escape sequence.
+    set_templates(R"([{"action":"replace","match":"a\\d","replacement":"OK"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?a1&x=1"), std::string("rtsp://192.0.2.10/c?a1&x=1"));
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?a\\d&x=1"), std::string("rtsp://192.0.2.10/c?OK&x=1"));
+}
+
+void test_replacement_placeholders()
+{
+    SUITE("expandReplacement: placeholders inside the 'replacement' string");
+
+    // A placeholder in the replacement means the same as "$1".
+    set_templates(R"([{"action":"replace","match":"seek={number}","replacement":"S={number}"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?seek=1234"), std::string("rtsp://192.0.2.10/c?S=1234"));
+
+    // Binding is by ordinal, not by wildcard kind: the first placeholder in the
+    // replacement is $1 even when it names a different wildcard than the group
+    // that captured the text.
+    set_templates(R"([{"action":"replace","match":"a={number}-{word}","replacement":"x={word}/{number}"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?a=12-ab"), std::string("rtsp://192.0.2.10/c?x=12/ab"));
+
+    // Three placeholders bind to $1/$2/$3 in order.
+    set_templates(R"([{"action":"replace","match":"t={number}-{word}-{any};","replacement":"[{any}][{number}][{word}]"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?t=12-ab-xy;&z=1"),
+             std::string("rtsp://192.0.2.10/c?[12][ab][xy]&z=1"));
+
+    // $1/$2 keep working and may be mixed in; the ordinal is counted over
+    // placeholders only, so "{number}" below is still the first one, i.e. $1.
+    set_templates(R"([{"action":"replace","match":"p={number}-{number}","replacement":"[$2][{number}]"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?p=1-2"), std::string("rtsp://192.0.2.10/c?[2][1]"));
+
+    // Braces that are not a documented placeholder are copied verbatim.
+    set_templates(R"([{"action":"replace","match":"k={word}","replacement":"{foo}=$1"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?k=abc"), std::string("rtsp://192.0.2.10/c?{foo}=abc"));
+
+    // "remove" ignores the replacement field entirely.
+    set_templates(R"([{"action":"remove","match":"d={number}","replacement":"{number}"}])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?d=5&x=1"), std::string("rtsp://192.0.2.10/c?&x=1"));
+}
+
+void test_malformed_templates()
+{
+    SUITE("rewrite_path: an unusable template is skipped, not fatal");
+
+    // Since every non-placeholder character is escaped, a match pattern can no
+    // longer produce an invalid regex; what is still rejectable is a template
+    // with the wrong shape. One of those must not cost the request the rules
+    // that would have handled it.
+
+    // "replace" without a "replacement".
+    set_templates(R"([
+        {"action":"replace","match":"/iptv/import"},
+        {"action":"remove","match":"/{number}_Uni.sdp"}
+    ])");
+    bool ok = false;
+    CHECK_EQ(rewrite("/tv/192.0.2.10/iptv/import/1_Uni.sdp?a=1", ok),
+             std::string("rtsp://192.0.2.10/iptv/import?a=1"));
+    CHECK(ok);
+
+    // "timeshift" without a "shift_hours", and with a non-integer one.
+    set_templates(R"([
+        {"action":"timeshift","match":"t={number}-{number}"},
+        {"action":"timeshift","match":"t={number}-{number}","shift_hours":"8"},
+        {"action":"remove","match":"&drop=1"}
+    ])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/c?t=0-60&drop=1", ok), std::string("rtsp://192.0.2.10/c?t=0-60"));
+    CHECK(ok);
+
+    // Entries missing a string action/match, and entries that are not objects at
+    // all, are skipped instead of throwing.
+    set_templates(R"([
+        {"match":"/live/{number}"},
+        {"action":"remove"},
+        {"action":5,"match":"/live/{number}"},
+        {"action":"remove","match":7},
+        "not-an-object",
+        null,
+        {"action":"remove","match":"/live/{number}"}
+    ])");
+    CHECK_EQ(rewrite("/tv/192.0.2.10/live/7?x=1", ok), std::string("rtsp://192.0.2.10?x=1"));
+    CHECK(ok);
 }
 
 void test_shipped_config_chain()
@@ -336,18 +427,23 @@ void test_shipped_config_chain()
     CHECK_EQ(rewrite("/tv/192.0.2.10/iptv/import/1_Uni.sdp?a=1"),
              std::string("rtsp://192.0.2.10/iptv?a=1"));
 
-    // The playback chain should annotate both timestamps with "GMT" and then
-    // shift them by -8h. It does not: simplifyToRegex is applied to "match"
-    // only, so the "{number}" tokens in "replacement" are inserted literally
-    // and the following timeshift rule then finds no digits to shift.
+    // The playback chain annotates both timestamps with "GMT" and the timeshift
+    // rule that follows then shifts them by -8h.
     bool ok = false;
-    std::string got = rewrite("/tv/192.0.2.10/PLTV/c?tvdr=20240101120000-20240101130000", ok);
+    CHECK_EQ(rewrite("/tv/192.0.2.10/PLTV/c?tvdr=20240101120000-20240101130000", ok),
+             std::string("rtsp://192.0.2.10/PLTV/c?tvdr=20240101040000GMT-20240101050000GMT"));
     CHECK(ok);
-    CHECK_EQ(got, std::string("rtsp://192.0.2.10/PLTV/c?tvdr={number}GMT-{number}GMT"));
-    XCHECK_EQ(got, std::string("rtsp://192.0.2.10/PLTV/c?tvdr=20240101040000GMT-20240101050000GMT"),
-              "placeholders are never expanded in the 'replacement' field (only $1/$2 work), "
-              "so the shipped playback rewrite emits literal '{number}' and the timeshift "
-              "rule that follows it never matches");
+
+    // Same chain with epoch timestamps: 1704110400 == 2024-01-01T12:00:00Z.
+    CHECK_EQ(rewrite("/tv/192.0.2.10/PLTV/c?tvdr=1704110400-1704114000"),
+             std::string("rtsp://192.0.2.10/PLTV/c?tvdr=20240101040000GMT-20240101050000GMT"));
+
+    // All four rules firing on one URL.
+    CHECK_EQ(rewrite("/tv/192.0.2.10/iptv/import/PLTV/1_Uni.sdp?tvdr=20240101120000-20240101130000"),
+             std::string("rtsp://192.0.2.10/iptv/PLTV?tvdr=20240101040000GMT-20240101050000GMT"));
+
+    // A URL the playback rules do not apply to is still carried through.
+    CHECK_EQ(rewrite("/tv/192.0.2.10/PLTV/c?other=1"), std::string("rtsp://192.0.2.10/PLTV/c?other=1"));
 }
 
 } // namespace
@@ -362,6 +458,8 @@ int main()
     test_actions();
     test_timeshift();
     test_regex_metacharacters();
+    test_replacement_placeholders();
+    test_malformed_templates();
     test_shipped_config_chain();
 
     return tst::summary();


### PR DESCRIPTION
## Summary

This PR promotes the accumulated `dev` branch improvements to `main`.

- add a comprehensive Meson unit-test suite and CI coverage
- harden request parsing, SSRF protection, transport parsing, configuration loading, and resource cleanup
- fix accept-loop CPU spinning and several socket/port lifecycle gaps
- repair playback URL rewriting, time-shift handling, keyframe waiting, and cross-origin token preservation
- improve Docker packaging by shipping the runtime config and Web UI
- preserve the complete RTSP redirect `Location`, including path and query parameters, across 301/302 hops

## Why

The proxy had several correctness and reliability gaps that could cause malformed upstream requests, leaked resources, CPU spinning, ineffective playback options, or rejected authenticated streams. In particular, the RTSP-to-RTSP redirect path previously changed only the upstream authority and reused the old request path, discarding the redirected path and query string.

## Impact

RTSP playback is more reliable across redirects and transport modes, security checks are stricter, configuration behavior is safer, and the core behavior now has repeatable regression coverage.

## Validation

- `meson test -C build --print-errorlogs`
- 9/9 test suites passed
- live end-to-end RTSP probe followed two 302 redirects and received H.264 1080p video plus MP2 audio through the proxy