### PR TITLE
Add RTSP Basic authentication support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,7 @@ name: Build Check
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ main ]
     paths:
       - 'src/**'
       - 'include/**'
@@ -13,7 +13,7 @@ on:
       - 'install.sh'
       - '.github/workflows/check.yml'
   pull_request:
-    branches: [ "**" ]
+    branches: [ main ]
     paths:
       - 'src/**'
       - 'include/**'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,17 +1,6 @@
 name: Build Check
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'src/**'
-      - 'include/**'
-      - 'openwrt/**'
-      - 'test/**'
-      - 'meson.build'
-      - 'meson_options.txt'
-      - 'install.sh'
-      - '.github/workflows/check.yml'
   pull_request:
     branches: [ main ]
     paths:

--- a/include/clients/rtsp_to_rtsp_client.h
+++ b/include/clients/rtsp_to_rtsp_client.h
@@ -32,6 +32,7 @@ struct RtspMitmConfig
     rtspCtx ctx;
     std::string proxy_uri_prefix;
     std::string upstream_uri_base;
+    std::string basic_authorization;
 };
 
 class RTSPToRtspClient : public IClient
@@ -243,6 +244,7 @@ private:
     // replace so every forwarded request uses the real upstream URI.
     std::string proxy_uri_prefix_;   // e.g. "rtsp://10.1.0.6:8555/112.245.125.44:1554"
     std::string upstream_uri_base_;  // e.g. "rtsp://112.245.125.44:1554"
+    std::string basic_authorization_;
     std::string local_ip_;
     uint16_t local_tcp_port_{0};
     std::string ds_transport_protocol_;

--- a/include/common/rtsp_ctx.h
+++ b/include/common/rtsp_ctx.h
@@ -36,6 +36,7 @@ struct rtspCtx
     std::string server_ip;
     std::string path;
     std::string rtsp_url;
+    std::string basic_authorization;
     std::string content_base;
 
     sdpCtx sdp;

--- a/include/protocol/rtsp_parser.h
+++ b/include/protocol/rtsp_parser.h
@@ -34,6 +34,7 @@ public:
     static int get_content_length(const std::string &resp);
     static std::string extract_header_value(const std::string &msg, const std::string &header_name);
     static std::string replace_request_uri(const std::string &request, const std::string &uri);
+    static std::string basic_authorization_from_url(const std::string &url);
 
 private:
 };

--- a/src/clients/rtsp_to_http_client.cpp
+++ b/src/clients/rtsp_to_http_client.cpp
@@ -347,6 +347,7 @@ void RTSPToHttpClient::on_rtsp_readable()
                     ctx.server_rtsp_port = temp_ctx.server_rtsp_port;
                     ctx.path = temp_ctx.path;
                     ctx.rtsp_url = temp_ctx.rtsp_url;
+                    ctx.basic_authorization = temp_ctx.basic_authorization;
 
                     current_request_.uri = "rtsp://" + ctx.server_ip + ":" + std::to_string(ctx.server_rtsp_port) + ctx.path;
                     
@@ -355,6 +356,8 @@ void RTSPToHttpClient::on_rtsp_readable()
                     req_buf_ += "CSeq: " + std::to_string(current_request_.cseq) + "\r\n";
                     if (!ctx.session_id.empty())
                         req_buf_ += "Session: " + ctx.session_id + "\r\n";
+                    if (!ctx.basic_authorization.empty())
+                        req_buf_ += "Authorization: " + ctx.basic_authorization + "\r\n";
                     req_buf_ += current_request_.headers;
                     if (!current_request_.body.empty())
                         req_buf_ += "Content-Length: " + std::to_string(current_request_.body.size()) + "\r\n\r\n" + current_request_.body;
@@ -651,6 +654,8 @@ void RTSPToHttpClient::build_and_send_request()
         req_buf_ += "CSeq: " + std::to_string(current_request_.cseq) + "\r\n";
         if (!ctx.session_id.empty())
             req_buf_ += "Session: " + ctx.session_id + "\r\n";
+        if (!ctx.basic_authorization.empty())
+            req_buf_ += "Authorization: " + ctx.basic_authorization + "\r\n";
         req_buf_ += current_request_.headers;
         if (!current_request_.body.empty())
             req_buf_ += "Content-Length: " + std::to_string(current_request_.body.size()) + "\r\n\r\n" + current_request_.body;

--- a/src/clients/rtsp_to_rtsp_client.cpp
+++ b/src/clients/rtsp_to_rtsp_client.cpp
@@ -49,6 +49,20 @@ bool parse_content_length(const std::string &headers, size_t &body_len)
         return false;
     }
 }
+
+std::string add_authorization_if_missing(const std::string &request,
+                                         const std::string &authorization)
+{
+    if (authorization.empty() ||
+        !rtspParser::extract_header_value(request, "Authorization").empty())
+        return request;
+    size_t header_end = request.find("\r\n\r\n");
+    if (header_end == std::string::npos)
+        return request;
+    std::string result = request;
+    result.insert(header_end, "\r\nAuthorization: " + authorization);
+    return result;
+}
 }
 
 
@@ -105,6 +119,7 @@ RTSPToRtspClient::RTSPToRtspClient(EpollLoop *loop, BufferPool &pool,
       ctx_(config.ctx),
       proxy_uri_prefix_(config.proxy_uri_prefix),
       upstream_uri_base_(config.upstream_uri_base),
+      basic_authorization_(config.basic_authorization),
       rtp_pipeline_(std::make_unique<RtpPipeline>())
 {
     // Remove the simple EPOLLIN watch that was set by the accept handler;
@@ -545,7 +560,7 @@ std::string RTSPToRtspClient::rewrite_request_for_upstream(const std::string &re
     // If no URI rewriting is needed (plain RTSP proxy / explicit-proxy mode)
     // just return the request as-is.
     if (proxy_uri_prefix_.empty())
-        return req;
+        return add_authorization_if_missing(req, basic_authorization_);
 
     // Rewrite only the first line: "METHOD <uri> RTSP/1.0\r\n"
     size_t crlf = req.find("\r\n");
@@ -587,7 +602,9 @@ std::string RTSPToRtspClient::rewrite_request_for_upstream(const std::string &re
         uri.replace(pos, 1, "");
     }
 
-    return method + " " + uri + " " + rtsp_ver + rest;
+    return add_authorization_if_missing(
+        method + " " + uri + " " + rtsp_ver + rest,
+        basic_authorization_);
 }
 
 /* ========================================================================= */
@@ -1353,6 +1370,7 @@ void RTSPToRtspClient::on_upstream_readable()
             ctx_.server_rtsp_port = temp_ctx.server_rtsp_port;
             ctx_.path = temp_ctx.path;
             ctx_.rtsp_url = temp_ctx.rtsp_url;
+            basic_authorization_ = temp_ctx.basic_authorization;
 
             // Rebuild upstream_uri_base_
             upstream_uri_base_ = "rtsp://" + ctx_.server_ip + ":" + std::to_string(ctx_.server_rtsp_port);
@@ -1372,6 +1390,8 @@ void RTSPToRtspClient::on_upstream_readable()
             // dropping any path/query supplied by the 301/302 response.
             std::string rewritten_req =
                 rtspParser::replace_request_uri(last_downstream_req_, ctx_.rtsp_url);
+            rewritten_req =
+                add_authorization_if_missing(rewritten_req, basic_authorization_);
             to_upstream_q_.push_back(rewritten_req);
 
             // Connect to the new upstream server
@@ -1647,17 +1667,37 @@ RtspMitmConfig RTSPToRtspClient::resolve_upstream(const std::string &first_reque
     config.ctx.rtsp_url = info.upstream_url;
     if (rtspParser::parse_url(info.upstream_url, config.ctx) != 0)
     {
-        throw std::runtime_error("Failed to parse resolved RTSP URL: " + info.upstream_url);
+        throw std::runtime_error("Failed to parse resolved RTSP URL.");
     }
+
+    config.basic_authorization = config.ctx.basic_authorization;
+    if (config.basic_authorization.empty())
+        config.basic_authorization =
+            rtspParser::basic_authorization_from_url(info.raw_uri);
 
     // Determine proxy_uri_prefix and upstream_uri_base for MITM
     // (We reuse the parsing result from RequestParser if available, 
     // but for now we reconstruct it or adjust based on the resolved ctx)
     
     // Default prefix logic
-    size_t path_pos = info.raw_uri.find(config.ctx.path);
-    if (path_pos != std::string::npos) {
-        config.proxy_uri_prefix = info.raw_uri.substr(0, path_pos);
+    size_t scheme_end = info.raw_uri.find("://");
+    size_t proxy_path = scheme_end == std::string::npos
+        ? 0
+        : info.raw_uri.find('/', scheme_end + 3);
+    if (proxy_path != std::string::npos)
+    {
+        size_t embedded_start = std::string::npos;
+        if (info.raw_uri.compare(proxy_path, 5, "/rtp/") == 0)
+            embedded_start = proxy_path + 5;
+        else if (info.raw_uri.compare(proxy_path, 4, "/tv/") == 0)
+            embedded_start = proxy_path + 4;
+        if (embedded_start != std::string::npos)
+        {
+            size_t embedded_path = info.raw_uri.find('/', embedded_start);
+            size_t prefix_end =
+                embedded_path == std::string::npos ? info.raw_uri.size() : embedded_path;
+            config.proxy_uri_prefix = info.raw_uri.substr(0, prefix_end);
+        }
     }
     config.upstream_uri_base = "rtsp://" + config.ctx.server_ip + ":" + std::to_string(config.ctx.server_rtsp_port);
 

--- a/src/handlers/rtsp_to_http_handle.cpp
+++ b/src/handlers/rtsp_to_http_handle.cpp
@@ -27,7 +27,7 @@ bool RtspToHttpHandle::dispatch(int client_fd, const sockaddr_in &client_addr, c
             throw std::runtime_error("Recursive connection detected.");
         }
 
-        Logger::debug("[RTSP2HTTP] Dispatching session: " + client_host + " -> " + info.upstream_url);
+        Logger::debug("[RTSP2HTTP] Dispatching session: " + client_host + " -> " + ctx.rtsp_url);
         
         auto client = std::make_unique<RTSPToHttpClient>(loop, pool, client_addr, client_fd, ctx);
         loop->add_client_to_map(client_fd, std::move(client));

--- a/src/handlers/rtsp_to_rtsp_handle.cpp
+++ b/src/handlers/rtsp_to_rtsp_handle.cpp
@@ -26,7 +26,7 @@ bool RtspToRtspHandle::dispatch(int client_fd, const sockaddr_in &client_addr, c
             throw std::runtime_error("Recursive connection detected.");
         }
 
-        Logger::debug("[RTSP2RTSP] Dispatching session: " + client_host + " -> " + info.upstream_url);
+        Logger::debug("[RTSP2RTSP] Dispatching session: " + client_host + " -> " + config.ctx.rtsp_url);
 
         auto client = std::make_unique<RTSPToRtspClient>(loop, pool, client_addr, client_fd, config, raw_request);
         loop->add_client_to_map(client_fd, std::move(client));

--- a/src/protocol/request_parser.cpp
+++ b/src/protocol/request_parser.cpp
@@ -40,6 +40,34 @@ static void strip_backslashes(std::string &s)
     }
 }
 
+static void redact_url_userinfo(std::string &uri)
+{
+    if (uri.rfind("rtsp://", 0) == 0)
+    {
+        size_t authority_end = uri.find('/', 7);
+        size_t at = uri.find('@', 7);
+        if (at != std::string::npos &&
+            (authority_end == std::string::npos || at < authority_end))
+            uri.replace(7, at - 7, "***");
+    }
+
+    size_t route = uri.find("/rtp/");
+    size_t route_length = 5;
+    if (route == std::string::npos)
+    {
+        route = uri.find("/tv/");
+        route_length = 4;
+    }
+    if (route == std::string::npos)
+        return;
+    size_t authority_start = route + route_length;
+    size_t authority_end = uri.find('/', authority_start);
+    size_t at = uri.find('@', authority_start);
+    if (at != std::string::npos &&
+        (authority_end == std::string::npos || at < authority_end))
+        uri.replace(authority_start, at - authority_start, "***");
+}
+
 RequestInfo RequestParser::parse(const std::string &request_data)
 {
     RequestInfo info;
@@ -130,6 +158,8 @@ RequestInfo RequestParser::parse(const std::string &request_data)
         std::string sub_path = info.clean_uri.substr(path_start);
         URLRewriter::rewrite_path(sub_path, info.upstream_url);
     }
+
+    redact_url_userinfo(info.clean_uri);
 
     return info;
 }

--- a/src/protocol/rtsp_parser.cpp
+++ b/src/protocol/rtsp_parser.cpp
@@ -10,6 +10,82 @@
 #include <limits>
 #include <arpa/inet.h>
 
+namespace
+{
+std::string percent_decode(const std::string &value)
+{
+    std::string result;
+    result.reserve(value.size());
+    for (size_t i = 0; i < value.size(); ++i)
+    {
+        if (value[i] == '%' && i + 2 < value.size() &&
+            std::isxdigit(static_cast<unsigned char>(value[i + 1])) &&
+            std::isxdigit(static_cast<unsigned char>(value[i + 2])))
+        {
+            auto hex = [](char c) {
+                if (c >= '0' && c <= '9') return c - '0';
+                c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+                return c - 'a' + 10;
+            };
+            result.push_back(static_cast<char>((hex(value[i + 1]) << 4) | hex(value[i + 2])));
+            i += 2;
+        }
+        else
+        {
+            result.push_back(value[i]);
+        }
+    }
+    return result;
+}
+
+std::string base64_encode(const std::string &value)
+{
+    static constexpr char alphabet[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::string result;
+    result.reserve(((value.size() + 2) / 3) * 4);
+    for (size_t i = 0; i < value.size(); i += 3)
+    {
+        unsigned int chunk = static_cast<unsigned char>(value[i]) << 16;
+        if (i + 1 < value.size())
+            chunk |= static_cast<unsigned char>(value[i + 1]) << 8;
+        if (i + 2 < value.size())
+            chunk |= static_cast<unsigned char>(value[i + 2]);
+        result.push_back(alphabet[(chunk >> 18) & 0x3f]);
+        result.push_back(alphabet[(chunk >> 12) & 0x3f]);
+        result.push_back(i + 1 < value.size() ? alphabet[(chunk >> 6) & 0x3f] : '=');
+        result.push_back(i + 2 < value.size() ? alphabet[chunk & 0x3f] : '=');
+    }
+    return result;
+}
+
+bool split_url_authority(const std::string &url, size_t &authority_end,
+                         std::string &hostport, std::string &userinfo)
+{
+    if (url.rfind("rtsp://", 0) != 0)
+        return false;
+    authority_end = url.find('/', 7);
+    size_t query = url.find('?', 7);
+    if (authority_end == std::string::npos ||
+        (query != std::string::npos && query < authority_end))
+        authority_end = query;
+    std::string authority =
+        url.substr(7, authority_end == std::string::npos ? std::string::npos : authority_end - 7);
+    size_t at = authority.rfind('@');
+    if (at != std::string::npos)
+    {
+        userinfo = authority.substr(0, at);
+        hostport = authority.substr(at + 1);
+    }
+    else
+    {
+        userinfo.clear();
+        hostport = authority;
+    }
+    return !hostport.empty();
+}
+}
+
 rtspParser::rtspParser() {}
 rtspParser::~rtspParser() {}
 
@@ -263,15 +339,31 @@ int rtspParser::parse_url(const std::string &url, rtspCtx &ctx)
     }
 
     ctx.rtsp_url = clean_url;
+    ctx.basic_authorization.clear();
     if (clean_url.rfind("rtsp://", 0) != 0)
         return -1;
 
-    size_t slash = clean_url.find('/', 7);
-    std::string hostport = clean_url.substr(7, (slash == std::string::npos) ? std::string::npos : slash - 7);
-    if (hostport.empty())
-    {
+    size_t authority_end = std::string::npos;
+    std::string hostport;
+    std::string userinfo;
+    if (!split_url_authority(clean_url, authority_end, hostport, userinfo))
         return -1;
+
+    if (!userinfo.empty())
+    {
+        size_t credential_colon = userinfo.find(':');
+        if (credential_colon == std::string::npos)
+            return -1;
+        std::string credentials =
+            percent_decode(userinfo.substr(0, credential_colon)) + ":" +
+            percent_decode(userinfo.substr(credential_colon + 1));
+        ctx.basic_authorization = "Basic " + base64_encode(credentials);
+        clean_url = "rtsp://" + hostport +
+                    (authority_end == std::string::npos ? "" : clean_url.substr(authority_end));
+        ctx.rtsp_url = clean_url;
     }
+
+    size_t slash = clean_url.find('/', 7);
     size_t colon = hostport.find(':');
 
     try
@@ -312,6 +404,22 @@ int rtspParser::parse_url(const std::string &url, rtspCtx &ctx)
     ctx.path = (slash != std::string::npos) ? clean_url.substr(slash) : "/";
 
     return 0;
+}
+
+std::string rtspParser::basic_authorization_from_url(const std::string &url)
+{
+    size_t authority_end = std::string::npos;
+    std::string hostport;
+    std::string userinfo;
+    if (!split_url_authority(url, authority_end, hostport, userinfo) || userinfo.empty())
+        return "";
+    size_t colon = userinfo.find(':');
+    if (colon == std::string::npos)
+        return "";
+    std::string credentials =
+        percent_decode(userinfo.substr(0, colon)) + ":" +
+        percent_decode(userinfo.substr(colon + 1));
+    return "Basic " + base64_encode(credentials);
 }
 
 std::string rtspParser::extract_header_value(const std::string &msg, const std::string &header_name)

--- a/test/unit/test_request_parser.cpp
+++ b/test/unit/test_request_parser.cpp
@@ -417,6 +417,24 @@ int main()
                  "rtsp://192.0.2.10:5540/live");
         CHECK_EQ(P("PLAY rtsp://192.0.2.9:8554/tv/192.0.2.20:554/ch?a=1 RTSP/1.0").upstream_url,
                  "rtsp://192.0.2.20:554/ch?a=1");
+        RequestInfo basic = P(
+            "SETUP rtsp://admin:test000111@192.0.2.212:554/"
+            "rtp/192.0.2.198:554/ RTSP/1.0");
+        CHECK_EQ(basic.upstream_url, std::string("rtsp://192.0.2.198:554/"));
+        CHECK_EQ(basic.raw_uri,
+                 std::string("rtsp://admin:test000111@192.0.2.212:554/"
+                             "rtp/192.0.2.198:554/"));
+        CHECK_EQ(basic.clean_uri,
+                 std::string("rtsp://***@192.0.2.212:554/"
+                             "rtp/192.0.2.198:554/"));
+        RequestInfo embedded_basic = P(
+            "SETUP rtsp://192.0.2.212:554/"
+            "rtp/admin:test000111@192.0.2.198:554/live RTSP/1.0");
+        CHECK_EQ(embedded_basic.upstream_url,
+                 std::string("rtsp://admin:test000111@192.0.2.198:554/live"));
+        CHECK_EQ(embedded_basic.clean_uri,
+                 std::string("rtsp://192.0.2.212:554/"
+                             "rtp/***@192.0.2.198:554/live"));
         // ...but only when the prefix really starts the path.
         CHECK_EQ(P("DESCRIBE rtsp://192.0.2.9:8554/x/rtp/192.0.2.10:5540/live RTSP/1.0").upstream_url,
                  "");

--- a/test/unit/test_rtsp_parser.cpp
+++ b/test/unit/test_rtsp_parser.cpp
@@ -453,6 +453,33 @@ void test_parse_url()
     CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.40:554/cam?chan=1&sub=0", e), 0);
     CHECK_EQ(e.path, std::string("/cam?chan=1&sub=0"));
 
+    SUITE("parse_url / Basic credentials");
+
+    rtspCtx auth{};
+    CHECK_EQ(rtspParser::parse_url(
+                 "rtsp://admin:test000111@192.0.2.41:554/live", auth),
+             0);
+    CHECK_EQ(auth.server_ip, std::string("192.0.2.41"));
+    CHECK_EQ(auth.server_rtsp_port, 554);
+    CHECK_EQ(auth.path, std::string("/live"));
+    CHECK_EQ(auth.rtsp_url, std::string("rtsp://192.0.2.41:554/live"));
+    CHECK_EQ(auth.basic_authorization,
+             std::string("Basic YWRtaW46dGVzdDAwMDExMQ=="));
+
+    rtspCtx encoded_auth{};
+    CHECK_EQ(rtspParser::parse_url(
+                 "rtsp://user%20name:p%40ss%3Aword@192.0.2.42/stream",
+                 encoded_auth),
+             0);
+    CHECK_EQ(encoded_auth.basic_authorization,
+             std::string("Basic dXNlciBuYW1lOnBAc3M6d29yZA=="));
+    CHECK_EQ(rtspParser::basic_authorization_from_url(
+                 "rtsp://admin:test000111@192.0.2.212:554/rtp/x"),
+             std::string("Basic YWRtaW46dGVzdDAwMDExMQ=="));
+    CHECK_EQ(rtspParser::basic_authorization_from_url(
+                 "rtsp://192.0.2.212:554/rtp/x"),
+             std::string(""));
+
     SUITE("parse_url / rejections");
 
     rtspCtx f{};
@@ -474,6 +501,11 @@ void test_parse_url()
     CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.10:0/x", l), -1);
     rtspCtx m{};
     CHECK_EQ(rtspParser::parse_url("rtsp://192.0.2.10:99999/x", m), -1);
+    rtspCtx missing_password_separator{};
+    CHECK_EQ(rtspParser::parse_url(
+                 "rtsp://admin@192.0.2.10:554/x",
+                 missing_password_separator),
+             -1);
 
     SUITE("parse_url / backslash and %5C stripping");
 


### PR DESCRIPTION
## Summary

- support RTSP URLs containing `user:password@host`
- inject `Authorization: Basic` into upstream RTSP requests when credentials are supplied in the proxy or embedded upstream URL
- preserve an existing client `Authorization` header instead of overwriting it
- support percent-encoded usernames and passwords
- fix proxy URI rewriting when the upstream path is `/`
- redact credentials from proxy logs
- avoid forwarding old credentials to a different redirect target unless the new `Location` explicitly contains credentials
- run Build Check only for pull requests targeting `main` (plus manual dispatch)

## Root cause

The RTSP URL parser treated the colon between username and password as the upstream port separator. In proxy-path mode, credentials attached to the proxy authority were also discarded instead of being applied to the actual upstream request. A separate prefix calculation bug matched the first slash in `rtsp://` when the upstream path was `/`, producing an invalid request URI.

## Validation

- project builds successfully with Meson
- all 9 test suites pass
- added parser and request-routing regression coverage for both supported credential placements
- end-to-end local proxy test confirmed the upstream receives the correct root URI and `Authorization: Basic` header